### PR TITLE
Let autogen.sh work on Darwin and Linux

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 bootstrap() {
-  libtoolize -c && \
+  case `uname` in Darwin*) glibtoolize --copy ;;
+                        *) libtoolize --copy ;; esac && \
   aclocal -I config && \
   automake -a -c && \
   autoconf


### PR DESCRIPTION
Darwin/Mac systems do not have libtoolize (or they do and it has a different function), it is called glibtoolize.  The stackoverflow item http://stackoverflow.com/questions/15448582/installed-libtool-but-libtoolize-not-found has more information.