### PR TITLE
Add missing abort to Mat_Error routine

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -301,6 +301,7 @@ void Mat_Error( const char *format, ... )
     va_start(ap, format );
     mat_log( LOG_LEVEL_ERROR, format, ap );
     va_end(ap);
+    abort();
 }
 
 /** @brief Prints a helpstring to stdout and exits with status 1


### PR DESCRIPTION
Description of routine states that it logs an error and then aborts, but it was missing the call to abort()