### PR TITLE
Minor Corrections

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,7 +46,7 @@ lib_LTLIBRARIES        = libmatio.la
 libmatio_la_SOURCES    = snprintf.c endian.c io.c $(ZLIB_SRC) read_data.c \
                          mat5.c mat4.c mat.c matvar_cell.c matvar_struct.c
 libmatio_la_LIBADD     = $(HDF5_LIBS) $(ZLIB_LIBS)
-libmatio_la_LDFLAGS    = -no-undefined -export-symbols matio.sym $(AM_LDFLAGS)
+libmatio_la_LDFLAGS    = -no-undefined -export-symbols @srcdir@/matio.sym $(AM_LDFLAGS)
 
 if MAT73
     libmatio_la_SOURCES+= mat73.c

--- a/src/mat.c
+++ b/src/mat.c
@@ -1579,6 +1579,8 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
         }
         return;
     } else if ( matvar->data == NULL || matvar->data_size < 1 ) {
+        if (printdata)
+            printf("{\n}\n");
         return;
     } else if ( MAT_C_CELL == matvar->class_type ) {
         matvar_t **cells = (matvar_t **)matvar->data;

--- a/test/mat5_compressed_read_be.at
+++ b/test/mat5_compressed_read_be.at
@@ -544,6 +544,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1
@@ -2769,6 +2771,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1

--- a/test/mat5_compressed_read_le.at
+++ b/test/mat5_compressed_read_le.at
@@ -544,6 +544,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1
@@ -2769,6 +2771,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1

--- a/test/mat5_compressed_write.at
+++ b/test/mat5_compressed_write.at
@@ -1268,6 +1268,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1

--- a/test/mat5_uncompressed_read_be.at
+++ b/test/mat5_uncompressed_read_be.at
@@ -516,6 +516,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1
@@ -2700,6 +2702,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1

--- a/test/mat5_uncompressed_read_le.at
+++ b/test/mat5_uncompressed_read_le.at
@@ -516,6 +516,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1
@@ -2700,6 +2702,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1

--- a/test/mat5_uncompressed_write.at
+++ b/test/mat5_uncompressed_write.at
@@ -1242,6 +1242,8 @@ Class Type: Double Precision Array
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1

--- a/test/mat73_compressed_write.at
+++ b/test/mat73_compressed_write.at
@@ -1147,6 +1147,8 @@ MATIO_AT_HOST_DATA([expout],
 Dimensions: 0 x 10
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
 ],[])
 AT_CHECK([$builddir/test_mat readvar test_write_empty_2d_numeric.mat empty],[0],
          [expout],[])
@@ -1261,11 +1263,15 @@ Fields@<:@2@:>@ {
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
 }
 ],[])
 AT_CHECK([$builddir/test_mat readvar test_write_empty_struct.mat var3],[0],
@@ -1282,11 +1288,15 @@ Fields@<:@4@:>@ {
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
  Data Type: 8-bit, unsigned integer
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1
@@ -3060,6 +3070,8 @@ Class Type: 8-bit, unsigned integer array (logical)
 Dimensions: 0 x 5
 Class Type: 8-bit, unsigned integer array (logical)
  Data Type: 8-bit, unsigned integer
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 5 x 5
@@ -3131,10 +3143,14 @@ Class Type: Cell Array
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
 }
 ],[])
 AT_CHECK([$builddir/test_mat readvar test_write_empty_cell.mat var2],[0],
@@ -4795,6 +4811,8 @@ Class Type: 8-bit, unsigned integer array (logical)
 Dimensions: 0 x 5
 Class Type: 8-bit, unsigned integer array (logical)
  Data Type: 8-bit, unsigned integer
+{
+}
 }
 ],[])
 AT_CHECK([$builddir/test_mat readvar test_write_cell_2d_logical.mat a],[0],

--- a/test/mat73_read_be.at
+++ b/test/mat73_read_be.at
@@ -465,6 +465,8 @@ AT_CHECK(
 Dimensions: 0 x 0
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
 ]], [])
 AT_CLEANUP
 
@@ -536,11 +538,15 @@ Fields@<:@4@:>@ {
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
  Data Type: 8-bit, unsigned integer
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1
@@ -1807,42 +1813,62 @@ Class Type: Cell Array
 Dimensions: 0 x 0
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: Single Precision Array
  Data Type: IEEE 754 single-precision
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 64-bit, signed integer array
  Data Type: 64-bit, signed integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 64-bit, unsigned integer array
  Data Type: 64-bit, unsigned integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 32-bit, signed integer array
  Data Type: 32-bit, signed integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 32-bit, unsigned integer array
  Data Type: 32-bit, unsigned integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 16-bit, signed integer array
  Data Type: 16-bit, signed integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 16-bit, unsigned integer array
  Data Type: 16-bit, unsigned integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 8-bit, signed integer array
  Data Type: 8-bit, signed integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 8-bit, unsigned integer array
  Data Type: 8-bit, unsigned integer
+{
+}
 }
 ], [])
 AT_CLEANUP
@@ -2740,11 +2766,15 @@ Fields@<:@4@:>@ {
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
  Data Type: 8-bit, unsigned integer
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1

--- a/test/mat73_read_le.at
+++ b/test/mat73_read_le.at
@@ -465,6 +465,8 @@ AT_CHECK(
 Dimensions: 0 x 0
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
 ]], [])
 AT_CLEANUP
 
@@ -536,11 +538,15 @@ Fields@<:@4@:>@ {
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
  Data Type: 8-bit, unsigned integer
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1
@@ -1807,42 +1813,62 @@ Class Type: Cell Array
 Dimensions: 0 x 0
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: Single Precision Array
  Data Type: IEEE 754 single-precision
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 64-bit, signed integer array
  Data Type: 64-bit, signed integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 64-bit, unsigned integer array
  Data Type: 64-bit, unsigned integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 32-bit, signed integer array
  Data Type: 32-bit, signed integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 32-bit, unsigned integer array
  Data Type: 32-bit, unsigned integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 16-bit, signed integer array
  Data Type: 16-bit, signed integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 16-bit, unsigned integer array
  Data Type: 16-bit, unsigned integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 8-bit, signed integer array
  Data Type: 8-bit, signed integer
+{
+}
       Rank: 2
 Dimensions: 0 x 0
 Class Type: 8-bit, unsigned integer array
  Data Type: 8-bit, unsigned integer
+{
+}
 }
 ], [])
 AT_CLEANUP
@@ -2740,11 +2766,15 @@ Fields@<:@4@:>@ {
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
  Data Type: 8-bit, unsigned integer
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1

--- a/test/mat73_write.at
+++ b/test/mat73_write.at
@@ -1123,6 +1123,8 @@ MATIO_AT_HOST_DATA([expout],
 Dimensions: 0 x 10
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
 ],[])
 AT_CHECK([$builddir/test_mat readvar test_write_empty_2d_numeric.mat empty],[0],
          [expout],[])
@@ -1235,11 +1237,15 @@ Fields@<:@2@:>@ {
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
 }
 ],[])
 AT_CHECK([$builddir/test_mat readvar test_write_empty_struct.mat var3],[0],
@@ -1256,11 +1262,15 @@ Fields@<:@4@:>@ {
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Character Array
  Data Type: 8-bit, unsigned integer
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 1
@@ -3013,6 +3023,8 @@ Class Type: 8-bit, unsigned integer array (logical)
 Dimensions: 0 x 5
 Class Type: 8-bit, unsigned integer array (logical)
  Data Type: 8-bit, unsigned integer
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 5 x 5
@@ -3074,16 +3086,22 @@ Fields@<:@4@:>@ {
 Dimensions: 0 x 0
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 0 x 0
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field1
       Rank: 2
 Dimensions: 0 x 0
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Name: field2
       Rank: 2
 Dimensions: 4 x 26
@@ -3155,10 +3173,14 @@ Class Type: Cell Array
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
       Rank: 2
 Dimensions: 0 x 1
 Class Type: Double Precision Array
  Data Type: IEEE 754 double-precision
+{
+}
 }
 ],[])
 AT_CHECK([$builddir/test_mat readvar test_write_empty_cell.mat var2],[0],
@@ -4798,6 +4820,8 @@ Class Type: 8-bit, unsigned integer array (logical)
 Dimensions: 0 x 5
 Class Type: 8-bit, unsigned integer array (logical)
  Data Type: 8-bit, unsigned integer
+{
+}
 }
 ],[])
 AT_CHECK([$builddir/test_mat readvar test_write_cell_2d_logical.mat a],[0],


### PR DESCRIPTION
This pull request corrects two small things.
Out of source build is broken because matio.sym is not found at the proper place (first commit).
The outputs of :
test_mat readvar matio_test_cases_hdf_le.mat  var23
test_mat readvar matio_test_cases_uncompressed_le.mat  var23
differ because the hdf reader sets matvar->data to NULL whereas it is non null in the second case (second commit).