### PR TITLE
C++

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -163,7 +163,7 @@ mat_log(int loglevel, const char *format, va_list ap)
     if ( !logfunc ) return;
     buffer = strdup_vprintf(format, ap);
     (*logfunc)(loglevel,buffer);
-    free(buffer);
+    DELETE_ARRAY(buffer);
     return;
 }
 

--- a/src/io.c
+++ b/src/io.c
@@ -70,7 +70,7 @@ strdup_vprintf(const char* format, va_list ap)
     size = mat_vsnprintf(NULL, 0, format, ap2)+1;
     va_end(ap2);
 
-    buffer = (char*)malloc(size+1);
+    buffer = NEW_ARRAY(char,size+1);
     if ( !buffer )
         return NULL;
 

--- a/src/mat.c
+++ b/src/mat.c
@@ -322,7 +322,7 @@ Mat_Open(const char *matname,int mode)
     if ( NULL == mat )
         return mat;
 
-    mat->filename = strdup_printf("%s",matname);
+    mat->filename = STRDUP(matname);
     mat->mode = mode;
 
     if ( mat->version == 0x0200 ) {
@@ -619,7 +619,7 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
     matvar->isGlobal    = opt & MAT_F_GLOBAL;
     matvar->isLogical   = opt & MAT_F_LOGICAL;
     if ( name )
-        matvar->name = strdup_printf("%s",name);
+        matvar->name = STRDUP(name);
     matvar->rank = rank;
     matvar->dims = NEW_ARRAY(size_t,matvar->rank);
     for ( i = 0; i < matvar->rank; i++ ) {
@@ -687,7 +687,7 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
                 if ( nfields ) {
                     matvar->internal->fieldnames = NEW_ARRAY(char*,nfields);
                     for ( i = 0; i < nfields; i++ )
-                        matvar->internal->fieldnames[i] = strdup(fields[i]->name);
+                        matvar->internal->fieldnames[i] = STRDUP(fields[i]->name);
                     nmemb *= nfields;
                 }
             }
@@ -865,7 +865,7 @@ Mat_VarDelete(mat_t *mat, const char *name)
             Mat_Close(tmp);
 
             if (err == 0) {
-                char *new_name = strdup_printf("%s",mat->filename);
+                char *new_name = STRDUP(mat->filename);
 #if defined(MAT73) && MAT73
                 if ( mat_file_ver == MAT_FT_MAT73 ) {
                     if ( mat->refs_id > -1 )
@@ -949,7 +949,7 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
     out->data = NULL;
 
     if ( NULL != in->internal->hdf5_name )
-        out->internal->hdf5_name = strdup(in->internal->hdf5_name);
+        out->internal->hdf5_name = STRDUP(in->internal->hdf5_name);
 
     out->internal->hdf5_ref = in->internal->hdf5_ref;
     out->internal->id       = in->internal->id;
@@ -964,7 +964,7 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
         out->internal->fieldnames = NEW_ARRAY(char*,in->internal->num_fields);
         for ( i = 0; i < in->internal->num_fields; i++ )
             out->internal->fieldnames[i] = ( NULL != in->internal->fieldnames[i] ) ?
-                                                strdup(in->internal->fieldnames[i]) : 0;
+                                                STRDUP(in->internal->fieldnames[i]) : 0;
     }
 
     if (in->name != NULL && (NULL != (out->name = NEW_ARRAY(char,strlen(in->name)+1))))

--- a/src/mat.c
+++ b/src/mat.c
@@ -506,41 +506,46 @@ Mat_VarCalloc(void)
 {
     matvar_t *matvar;
 
-    matvar = NEW(matvar_t);
-
-    if ( NULL != matvar ) {
-        matvar->nbytes       = 0;
-        matvar->rank         = 0;
-        matvar->data_type    = MAT_T_UNKNOWN;
-        matvar->data_size    = 0;
-        matvar->class_type   = MAT_C_EMPTY;
-        matvar->isComplex    = 0;
-        matvar->isGlobal     = 0;
-        matvar->isLogical    = 0;
-        matvar->dims         = NULL;
-        matvar->name         = NULL;
-        matvar->data         = NULL;
-        matvar->mem_conserve = 0;
-        matvar->compression  = MAT_COMPRESSION_NONE;
-        matvar->internal     = NEW(struct matvar_internal);
-        if ( NULL == matvar->internal ) {
-            DELETE_ARRAY(matvar);
-            matvar = NULL;
-        } else {
-            matvar->internal->hdf5_name = NULL;
-            matvar->internal->hdf5_ref  =  0;
-            matvar->internal->id        = -1;
-            matvar->internal->fp = NULL;
-            matvar->internal->fpos       = 0;
-            matvar->internal->datapos    = 0;
-            matvar->internal->fieldnames = NULL;
-            matvar->internal->num_fields = 0;
-#if defined(HAVE_ZLIB)
-            matvar->internal->z          = NULL;
-            matvar->internal->data       = NULL;
-#endif
-        }
+    TRY {
+        matvar = NEW(matvar_t);
+    } CATCH(matvar==NULL) {
+        END(Mat_Critical("Memory allocation failure"),NULL);
     }
+
+    matvar->nbytes       = 0;
+    matvar->rank         = 0;
+    matvar->data_type    = MAT_T_UNKNOWN;
+    matvar->data_size    = 0;
+    matvar->class_type   = MAT_C_EMPTY;
+    matvar->isComplex    = 0;
+    matvar->isGlobal     = 0;
+    matvar->isLogical    = 0;
+    matvar->dims         = NULL;
+    matvar->name         = NULL;
+    matvar->data         = NULL;
+    matvar->mem_conserve = 0;
+    matvar->compression  = MAT_COMPRESSION_NONE;
+
+    TRY {
+        matvar->internal = NEW(struct matvar_internal);
+    } CATCH(matvar->internal==NULL) {
+        DELETE(matvar);
+        matvar = NULL;
+        END(Mat_Critical("Memory allocation failure"),NULL);
+    }
+
+    matvar->internal->hdf5_name = NULL;
+    matvar->internal->hdf5_ref  =  0;
+    matvar->internal->id        = -1;
+    matvar->internal->fp = NULL;
+    matvar->internal->fpos       = 0;
+    matvar->internal->datapos    = 0;
+    matvar->internal->fieldnames = NULL;
+    matvar->internal->num_fields = 0;
+#if defined(HAVE_ZLIB)
+    matvar->internal->z          = NULL;
+    matvar->internal->data       = NULL;
+#endif
 
     return matvar;
 }

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -369,7 +369,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                 sparse->ir = NEW_ARRAY(mat_int32_t,sparse->nir);
 
             } CATCH(sparse->ir==NULL) {
-                DELETE_ARRAY(matvar->data);
+                DELETE_BUFFER(matvar->data);
                 matvar->data = NULL;
                 V_END(Mat_Critical("Memory allocation failure"));
             }
@@ -385,7 +385,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                 fpos = ftell((FILE*)mat->fp);
             } CATCH(fpos==-1L) {
                 DELETE_ARRAY(sparse->ir);
-                DELETE_ARRAY(matvar->data);
+                DELETE_BUFFER(matvar->data);
                 matvar->data = NULL;
                 V_END(Mat_Critical("Couldn't determine file position"));
             }
@@ -396,7 +396,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                 ReadDoubleData(mat, &tmp, data_type, 1);
             } CATCH ( tmp > INT_MAX-1 || tmp < 0 ) {
                 DELETE_ARRAY(sparse->ir);
-                DELETE_ARRAY(matvar->data);
+                DELETE_BUFFER(matvar->data);
                 matvar->data = NULL;
                 V_END(Mat_Critical("Invalid column dimension for sparse matrix"));
             }
@@ -406,7 +406,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                 (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
             } CATCH ( matvar->dims[1] > INT_MAX-1 ) {
                 DELETE_ARRAY(sparse->ir);
-                DELETE_ARRAY(matvar->data);
+                DELETE_BUFFER(matvar->data);
                 matvar->data = NULL;
                 V_END(Mat_Critical("Invalid column dimension for sparse matrix"));
             }
@@ -416,7 +416,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                 sparse->jc = NEW_ARRAY(mat_int32_t,sparse->njc);
             } CATCH(sparse->jc == NULL) {
                 DELETE_ARRAY(sparse->ir);
-                DELETE_ARRAY(matvar->data);
+                DELETE_BUFFER(matvar->data);
                 matvar->data = NULL;
                 V_END(Mat_Critical("Memory allocation failure"));
             }
@@ -426,7 +426,7 @@ Read4(mat_t *mat,matvar_t *matvar)
             } CATCH( jc == NULL ) {
                 DELETE_ARRAY(sparse->jc);
                 DELETE_ARRAY(sparse->ir);
-                DELETE_ARRAY(matvar->data);
+                DELETE_BUFFER(matvar->data);
                 matvar->data = NULL;
                 V_END(Mat_Critical("Memory allocation failure"));
             }
@@ -454,7 +454,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                 } CATCH( complex_data == NULL ) {
                     DELETE_ARRAY(sparse->jc);
                     DELETE_ARRAY(sparse->ir);
-                    DELETE_ARRAY(matvar->data);
+                    DELETE_BUFFER(matvar->data);
                     matvar->data = NULL;
                     V_END(Mat_Critical("Memory allocation failure"));
                 }
@@ -467,7 +467,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                     DELETE(complex_data);
                     DELETE_ARRAY(sparse->jc);
                     DELETE_ARRAY(sparse->ir);
-                    DELETE_ARRAY(matvar->data);
+                    DELETE_BUFFER(matvar->data);
                     matvar->data = NULL;
                     V_END(Mat_Critical("Memory allocation failure"));
                 }
@@ -537,12 +537,12 @@ Read4(mat_t *mat,matvar_t *matvar)
                         break;
                     }
                     default:
-                        DELETE_ARRAY(complex_data->Re);
-                        DELETE_ARRAY(complex_data->Im);
+                        DELETE_BUFFER(complex_data->Re);
+                        DELETE_BUFFER(complex_data->Im);
                         DELETE(complex_data);
                         DELETE_ARRAY(sparse->jc);
                         DELETE_ARRAY(sparse->ir);
-                        DELETE_ARRAY(matvar->data);
+                        DELETE_BUFFER(matvar->data);
                         matvar->data = NULL;
                         V_END(Mat_Critical("Read4: %d is not a supported data type for ",
                               "extended sparse", data_type));
@@ -561,7 +561,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                 } CATCH( sparse->data == NULL ) {
                     DELETE_ARRAY(sparse->jc);
                     DELETE_ARRAY(sparse->ir);
-                    DELETE_ARRAY(matvar->data);
+                    DELETE_BUFFER(matvar->data);
                     matvar->data = NULL;
                     V_END(Mat_Critical("Memory allocation failure"));
                 }
@@ -613,10 +613,10 @@ Read4(mat_t *mat,matvar_t *matvar)
                         break;
                     }
                     default:
-                        DELETE_ARRAY(sparse->data);
+                        DELETE_BUFFER(sparse->data);
                         DELETE_ARRAY(sparse->jc);
                         DELETE_ARRAY(sparse->ir);
-                        DELETE_ARRAY(matvar->data);
+                        DELETE_BUFFER(matvar->data);
                         matvar->data = NULL;
                         V_END(Mat_Critical("Read4: %d is not a supported data type for ",
                                  "extended sparse", data_type));

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -350,7 +350,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                     for ( i = 0; i < sparse->nir; i++ )
                         sparse->ir[i] = sparse->ir[i] - 1;
                 } else {
-                    free(matvar->data);
+                    DELETE_ARRAY(matvar->data);
                     matvar->data = NULL;
                     Mat_Critical("Memory allocation failure");
                     return;
@@ -360,8 +360,8 @@ Read4(mat_t *mat,matvar_t *matvar)
 
                 fpos = ftell((FILE*)mat->fp);
                 if ( fpos == -1L ) {
-                    free(sparse->ir);
-                    free(matvar->data);
+                    DELETE_ARRAY(sparse->ir);
+                    DELETE_ARRAY(matvar->data);
                     matvar->data = NULL;
                     Mat_Critical("Couldn't determine file position");
                     return;
@@ -370,8 +370,8 @@ Read4(mat_t *mat,matvar_t *matvar)
                     SEEK_CUR);
                 ReadDoubleData(mat, &tmp, data_type, 1);
                 if ( tmp > INT_MAX-1 || tmp < 0 ) {
-                    free(sparse->ir);
-                    free(matvar->data);
+                    DELETE_ARRAY(sparse->ir);
+                    DELETE_ARRAY(matvar->data);
                     matvar->data = NULL;
                     Mat_Critical("Invalid column dimension for sparse matrix");
                     return;
@@ -379,8 +379,8 @@ Read4(mat_t *mat,matvar_t *matvar)
                 matvar->dims[1] = tmp < 0 ? 0 : ( tmp > INT_MAX-1 ? INT_MAX-1 : (size_t)tmp );
                 (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
                 if ( matvar->dims[1] > INT_MAX-1 ) {
-                    free(sparse->ir);
-                    free(matvar->data);
+                    DELETE_ARRAY(sparse->ir);
+                    DELETE_ARRAY(matvar->data);
                     matvar->data = NULL;
                     Mat_Critical("Invalid column dimension for sparse matrix");
                     return;
@@ -399,20 +399,20 @@ Read4(mat_t *mat,matvar_t *matvar)
                                 j++;
                             sparse->jc[i] = j;
                         }
-                        free(jc);
+                        DELETE_ARRAY(jc);
                         /* terminating nnz */
                         sparse->jc[sparse->njc-1] = sparse->nir;
                     } else {
-                        free(sparse->jc);
-                        free(sparse->ir);
-                        free(matvar->data);
+                        DELETE_ARRAY(sparse->jc);
+                        DELETE_ARRAY(sparse->ir);
+                        DELETE_ARRAY(matvar->data);
                         matvar->data = NULL;
                         Mat_Critical("Memory allocation failure");
                         return;
                     }
                 } else {
-                    free(sparse->ir);
-                    free(matvar->data);
+                    DELETE_ARRAY(sparse->ir);
+                    DELETE_ARRAY(matvar->data);
                     matvar->data = NULL;
                     Mat_Critical("Memory allocation failure");
                     return;
@@ -495,12 +495,12 @@ Read4(mat_t *mat,matvar_t *matvar)
                                     break;
                                 }
                                 default:
-                                    free(complex_data->Re);
-                                    free(complex_data->Im);
-                                    free(complex_data);
-                                    free(sparse->jc);
-                                    free(sparse->ir);
-                                    free(matvar->data);
+                                    DELETE_ARRAY(complex_data->Re);
+                                    DELETE_ARRAY(complex_data->Im);
+                                    DELETE(complex_data);
+                                    DELETE_ARRAY(sparse->jc);
+                                    DELETE_ARRAY(sparse->ir);
+                                    DELETE_ARRAY(matvar->data);
                                     matvar->data = NULL;
                                     Mat_Critical("Read4: %d is not a supported data type for ",
                                         "extended sparse", data_type);
@@ -567,10 +567,10 @@ Read4(mat_t *mat,matvar_t *matvar)
                                 break;
                             }
                             default:
-                                free(sparse->data);
-                                free(sparse->jc);
-                                free(sparse->ir);
-                                free(matvar->data);
+                                DELETE_ARRAY(sparse->data);
+                                DELETE_ARRAY(sparse->jc);
+                                DELETE_ARRAY(sparse->ir);
+                                DELETE_ARRAY(matvar->data);
                                 matvar->data = NULL;
                                 Mat_Critical("Read4: %d is not a supported data type for ",
                                     "extended sparse", data_type);
@@ -581,9 +581,9 @@ Read4(mat_t *mat,matvar_t *matvar)
                         ReadDoubleData(mat, &tmp, data_type, 1);
 #endif
                     } else {
-                        free(sparse->jc);
-                        free(sparse->ir);
-                        free(matvar->data);
+                        DELETE_ARRAY(sparse->jc);
+                        DELETE_ARRAY(sparse->ir);
+                        DELETE_ARRAY(matvar->data);
                         matvar->data = NULL;
                         Mat_Critical("Memory allocation failure");
                         return;

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -90,7 +90,7 @@ Mat_Create4(const char* matname)
         mat = NEW(mat_t);
     } CATCH(mat==NULL) {
         fclose(fp);
-        END(Mat_Critical("Couldn't allocate memory for the MAT file"));
+        END(Mat_Critical("Couldn't allocate memory for the MAT file"),NULL);
     }
 
     mat->header        = NULL;
@@ -787,16 +787,16 @@ Mat_VarReadNextInfo4(mat_t *mat)
     } endian;
 
     if ( mat == NULL || mat->fp == NULL )
-        END(Mat_Critical("Bad mat descriptor"));
+        END(Mat_Critical("Bad mat descriptor"),NULL);
     else if ( NULL == (matvar = Mat_VarCalloc()) )
-        END(Mat_Critical("Memory allocation failure"));
+        END(Mat_Critical("Memory allocation failure"),NULL);
 
     TRY {
         matvar->internal->fp   = mat;
         matvar->internal->fpos = ftell((FILE*)mat->fp);
     } CATCH ( matvar->internal->fpos == -1L ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Couldn't determine file position"));
+        END(Mat_Critical("Couldn't determine file position"),NULL);
     }
 
     err = fread(&tmp,sizeof(int),1,(FILE*)mat->fp);
@@ -811,7 +811,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
     if ( tmp < 0 || tmp > 4052 ) {
         if ( Mat_int32Swap(&tmp) > 4052 ) {
             Mat_VarFree(matvar);
-            END(Mat_Critical("Bad data descriptor"));
+            END(Mat_Critical("Bad data descriptor"),NULL);
         }
     }
 
@@ -835,12 +835,12 @@ Mat_VarReadNextInfo4(mat_t *mat)
         default:
             /* VAX, Cray, or bogus */
             Mat_VarFree(matvar);
-            END(Mat_Critical("Wrong/Unsupported floating point format"));
+            END(Mat_Critical("Wrong/Unsupported floating point format"),NULL);
     }
     /* O must be zero */
     if ( 0 != O ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Bad data descriptor"));
+        END(Mat_Critical("Bad data descriptor"),NULL);
     }
     /* Convert the V4 data type */
     switch ( data_type ) {
@@ -864,7 +864,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
             break;
         default:
             Mat_VarFree(matvar);
-            END(Mat_Critical("Wrong data type"));
+            END(Mat_Critical("Wrong data type"),NULL);
     }
     switch ( class_type ) {
         case 0:
@@ -878,14 +878,14 @@ Mat_VarReadNextInfo4(mat_t *mat)
             break;
         default:
             Mat_VarFree(matvar);
-            END(Mat_Critical("Wrong class type"));
+            END(Mat_Critical("Wrong class type"),NULL);
     }
     matvar->rank = 2;
     TRY {
         matvar->dims = NEW_ARRAY(size_t,2);
     } CATCH ( NULL == matvar->dims ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Memory allocation failure"));
+        END(Mat_Critical("Memory allocation failure"),NULL);
     }
 
     TRY {
@@ -895,7 +895,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
         matvar->dims[0] = tmp;
     } CATCH ( !err ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Couldn't read data from file"));
+        END(Mat_Critical("Couldn't read data from file"),NULL);
     }
 
     TRY {
@@ -905,7 +905,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
         matvar->dims[1] = tmp;
     } CATCH( !err ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Couldn't read data from file"));
+        END(Mat_Critical("Couldn't read data from file"),NULL);
     }
 
     TRY {
@@ -913,7 +913,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
         //  No byte swap here. This is stange. TODO: POSSIBLE BUG.
     } CATCH( !err ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Couldn't read data from file"));
+        END(Mat_Critical("Couldn't read data from file"),NULL);
     }
 
     TRY {
@@ -922,32 +922,32 @@ Mat_VarReadNextInfo4(mat_t *mat)
             Mat_int32Swap(&tmp);
     } CATCH( !err ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Couldn't read data from file"));
+        END(Mat_Critical("Couldn't read data from file"),NULL);
     }
     /* Check that the length of the variable name is at least 1 */
     if ( tmp < 1 ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Length of variable name must be at least 1"));
+        END(Mat_Critical("Length of variable name must be at least 1"),NULL);
     }
 
     TRY {
         matvar->name = NEW_ARRAY(char,tmp);
     } CATCH ( NULL == matvar->name ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Memory allocation failure"));
+        END(Mat_Critical("Memory allocation failure"),NULL);
     }
 
     TRY {
         err = fread(matvar->name,1,tmp,(FILE*)mat->fp);
     } CATCH( !err ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Couldn't read data from file"));
+        END(Mat_Critical("Couldn't read data from file"),NULL);
     }
 
     matvar->internal->datapos = ftell((FILE*)mat->fp);
     if ( matvar->internal->datapos == -1L ) {
         Mat_VarFree(matvar);
-        END(Mat_Critical("Couldn't determine file position"));
+        END(Mat_Critical("Couldn't determine file position"),NULL);
     }
     nBytes = matvar->dims[0]*matvar->dims[1]*Mat_SizeOf(matvar->data_type);
     if ( matvar->isComplex )

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -86,11 +86,11 @@ Mat_Create4(const char* matname)
     if ( !fp )
         return NULL;
 
-    mat = NEW(mat_t);
-    if ( NULL == mat ) {
+    TRY {
+        mat = NEW(mat_t);
+    } CATCH(mat==NULL) {
         fclose(fp);
-        Mat_Critical("Couldn't allocate memory for the MAT file");
-        return NULL;
+        END(Mat_Critical("Couldn't allocate memory for the MAT file"));
     }
 
     mat->header        = NULL;
@@ -299,20 +299,31 @@ Read4(mat_t *mat,matvar_t *matvar)
             if ( matvar->isComplex ) {
                 mat_complex_split_t *complex_data;
 
-                complex_data = NEW(mat_complex_split_t);
-                if ( complex_data != NULL ) {
+                TRY {
+                    complex_data = NEW(mat_complex_split_t);
+                } CATCH(complex_data==NULL) {
+                    V_END(Mat_Critical("Memory allocation failure"));
+                }
+
+                TRY {
                     complex_data->Re = NEW_ARRAY(char,matvar->nbytes);
                     complex_data->Im = NEW_ARRAY(char,matvar->nbytes);
                     matvar->data     = complex_data;
-                    if ( complex_data->Re != NULL && complex_data->Im != NULL ) {
-                        ReadDoubleData(mat, (double*)complex_data->Re, matvar->data_type, N);
-                        ReadDoubleData(mat, (double*)complex_data->Im, matvar->data_type, N);
-                    }
+                } CATCH(complex_data->Re == NULL || complex_data->Im == NULL) {
+                    V_END(Mat_Critical("Memory allocation failure"));
                 }
+
+                ReadDoubleData(mat, (double*)complex_data->Re, matvar->data_type, N);
+                ReadDoubleData(mat, (double*)complex_data->Im, matvar->data_type, N);
+
             } else {
-                matvar->data = NEW_ARRAY(char,matvar->nbytes);
-                if ( matvar->data != NULL )
-                    ReadDoubleData(mat, (double*)matvar->data, matvar->data_type, N);
+                TRY {
+                    matvar->data = NEW_ARRAY(char,matvar->nbytes);
+                } CATCH(matvar->data == NULL ) {
+                    V_END(Mat_Critical("Memory allocation failure"));
+                }
+
+                ReadDoubleData(mat, (double*)matvar->data, matvar->data_type, N);
             }
             /* Update data type to match format of matvar->data */
             matvar->data_type = MAT_T_DOUBLE;
@@ -320,280 +331,305 @@ Read4(mat_t *mat,matvar_t *matvar)
         case MAT_C_CHAR:
             matvar->data_size = 1;
             matvar->nbytes = N;
-            matvar->data = NEW_ARRAY(char,matvar->nbytes);
-            if ( NULL == matvar->data )
-                Mat_Critical("Memory allocation failure");
-            else
-                ReadUInt8Data(mat,(mat_uint8_t*)matvar->data,matvar->data_type,N);
+
+            TRY {
+                matvar->data = NEW_ARRAY(char,matvar->nbytes);
+            } CATCH (matvar->data==NULL) {
+                V_END(Mat_Critical("Memory allocation failure"));
+            }
+
+            ReadUInt8Data(mat,(mat_uint8_t*)matvar->data,matvar->data_type,N);
             matvar->data_type = MAT_T_UINT8;
             break;
-        case MAT_C_SPARSE:
+        case MAT_C_SPARSE: {
+
+            double tmp;
+            int i,j;
+            mat_sparse_t* sparse;
+            mat_int32_t *jc;
+            long fpos;
+
             matvar->data_size = sizeof(mat_sparse_t);
-            matvar->data      = NEW_ARRAY(char,matvar->data_size);
-            if ( matvar->data == NULL )
-                Mat_Critical("Memory allocation failure");
-            else {
-                double tmp;
-                int i;
-                mat_sparse_t* sparse;
-                long fpos;
-                enum matio_types data_type = MAT_T_DOUBLE;
 
-                /* matvar->dims[1] either is 3 for real or 4 for complex sparse */
-                matvar->isComplex = matvar->dims[1] == 4 ? 1 : 0;
-                sparse = (mat_sparse_t*)matvar->data;
-                sparse->nir = matvar->dims[0] - 1;
-                sparse->nzmax = sparse->nir;
+            TRY {
+                matvar->data = NEW_ARRAY(char,matvar->data_size);
+            } CATCH (matvar->data==NULL) {
+                V_END(Mat_Critical("Memory allocation failure"));
+            }
+
+            enum matio_types data_type = MAT_T_DOUBLE;
+
+            /* matvar->dims[1] either is 3 for real or 4 for complex sparse */
+            matvar->isComplex = matvar->dims[1] == 4 ? 1 : 0;
+            sparse = (mat_sparse_t*)matvar->data;
+            sparse->nir = matvar->dims[0] - 1;
+            sparse->nzmax = sparse->nir;
+
+            TRY {
                 sparse->ir = NEW_ARRAY(mat_int32_t,sparse->nir);
-                if ( sparse->ir != NULL ) {
-                    ReadInt32Data(mat, sparse->ir, data_type, sparse->nir);
-                    for ( i = 0; i < sparse->nir; i++ )
-                        sparse->ir[i] = sparse->ir[i] - 1;
-                } else {
-                    DELETE_ARRAY(matvar->data);
-                    matvar->data = NULL;
-                    Mat_Critical("Memory allocation failure");
-                    return;
-                }
-                ReadDoubleData(mat, &tmp, data_type, 1);
-                matvar->dims[0] = tmp;
 
+            } CATCH(sparse->ir==NULL) {
+                DELETE_ARRAY(matvar->data);
+                matvar->data = NULL;
+                V_END(Mat_Critical("Memory allocation failure"));
+            }
+
+            ReadInt32Data(mat, sparse->ir, data_type, sparse->nir);
+            for ( i = 0; i < sparse->nir; i++ )
+                sparse->ir[i] = sparse->ir[i] - 1;
+
+            ReadDoubleData(mat, &tmp, data_type, 1);
+            matvar->dims[0] = tmp;
+
+            TRY {
                 fpos = ftell((FILE*)mat->fp);
-                if ( fpos == -1L ) {
-                    DELETE_ARRAY(sparse->ir);
-                    DELETE_ARRAY(matvar->data);
-                    matvar->data = NULL;
-                    Mat_Critical("Couldn't determine file position");
-                    return;
-                }
+            } CATCH(fpos==-1L) {
+                DELETE_ARRAY(sparse->ir);
+                DELETE_ARRAY(matvar->data);
+                matvar->data = NULL;
+                V_END(Mat_Critical("Couldn't determine file position"));
+            }
+
+            TRY {
                 (void)fseek((FILE*)mat->fp,sparse->nir*Mat_SizeOf(data_type),
                     SEEK_CUR);
                 ReadDoubleData(mat, &tmp, data_type, 1);
-                if ( tmp > INT_MAX-1 || tmp < 0 ) {
-                    DELETE_ARRAY(sparse->ir);
-                    DELETE_ARRAY(matvar->data);
-                    matvar->data = NULL;
-                    Mat_Critical("Invalid column dimension for sparse matrix");
-                    return;
-                }
-                matvar->dims[1] = tmp < 0 ? 0 : ( tmp > INT_MAX-1 ? INT_MAX-1 : (size_t)tmp );
+            } CATCH ( tmp > INT_MAX-1 || tmp < 0 ) {
+                DELETE_ARRAY(sparse->ir);
+                DELETE_ARRAY(matvar->data);
+                matvar->data = NULL;
+                V_END(Mat_Critical("Invalid column dimension for sparse matrix"));
+            }
+            matvar->dims[1] = tmp < 0 ? 0 : ( tmp > INT_MAX-1 ? INT_MAX-1 : (size_t)tmp );
+
+            TRY {
                 (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
-                if ( matvar->dims[1] > INT_MAX-1 ) {
-                    DELETE_ARRAY(sparse->ir);
-                    DELETE_ARRAY(matvar->data);
-                    matvar->data = NULL;
-                    Mat_Critical("Invalid column dimension for sparse matrix");
-                    return;
-                }
+            } CATCH ( matvar->dims[1] > INT_MAX-1 ) {
+                DELETE_ARRAY(sparse->ir);
+                DELETE_ARRAY(matvar->data);
+                matvar->data = NULL;
+                V_END(Mat_Critical("Invalid column dimension for sparse matrix"));
+            }
+
+            TRY {
                 sparse->njc = (int)matvar->dims[1] + 1;
                 sparse->jc = NEW_ARRAY(mat_int32_t,sparse->njc);
-                if ( sparse->jc != NULL ) {
-                    mat_int32_t *jc;
-                    jc = NEW_ARRAY(mat_int32_t,sparse->nir);
-                    if ( jc != NULL ) {
-                        int j = 0;
-                        sparse->jc[0] = 0;
-                        ReadInt32Data(mat, jc, data_type, sparse->nir);
-                        for ( i = 1; i < sparse->njc-1; i++ ) {
-                            while ( j < sparse->nir && jc[j] <= i )
-                                j++;
-                            sparse->jc[i] = j;
-                        }
-                        DELETE_ARRAY(jc);
-                        /* terminating nnz */
-                        sparse->jc[sparse->njc-1] = sparse->nir;
-                    } else {
-                        DELETE_ARRAY(sparse->jc);
-                        DELETE_ARRAY(sparse->ir);
-                        DELETE_ARRAY(matvar->data);
-                        matvar->data = NULL;
-                        Mat_Critical("Memory allocation failure");
-                        return;
-                    }
-                } else {
+            } CATCH(sparse->jc == NULL) {
+                DELETE_ARRAY(sparse->ir);
+                DELETE_ARRAY(matvar->data);
+                matvar->data = NULL;
+                V_END(Mat_Critical("Memory allocation failure"));
+            }
+
+            TRY {
+                jc = NEW_ARRAY(mat_int32_t,sparse->nir);
+            } CATCH( jc == NULL ) {
+                DELETE_ARRAY(sparse->jc);
+                DELETE_ARRAY(sparse->ir);
+                DELETE_ARRAY(matvar->data);
+                matvar->data = NULL;
+                V_END(Mat_Critical("Memory allocation failure"));
+            }
+
+            j = 0;
+            sparse->jc[0] = 0;
+            ReadInt32Data(mat, jc, data_type, sparse->nir);
+            for ( i = 1; i < sparse->njc-1; i++ ) {
+                while ( j < sparse->nir && jc[j] <= i )
+                    j++;
+                sparse->jc[i] = j;
+            }
+            DELETE_ARRAY(jc);
+            /* terminating nnz */
+            sparse->jc[sparse->njc-1] = sparse->nir;
+
+            ReadDoubleData(mat, &tmp, data_type, 1);
+            sparse->ndata = sparse->nir;
+            data_type = matvar->data_type;
+            if ( matvar->isComplex ) {
+                mat_complex_split_t *complex_data;
+
+                TRY {
+                    complex_data = NEW(mat_complex_split_t);
+                } CATCH( complex_data == NULL ) {
+                    DELETE_ARRAY(sparse->jc);
                     DELETE_ARRAY(sparse->ir);
                     DELETE_ARRAY(matvar->data);
                     matvar->data = NULL;
-                    Mat_Critical("Memory allocation failure");
-                    return;
+                    V_END(Mat_Critical("Memory allocation failure"));
                 }
-                ReadDoubleData(mat, &tmp, data_type, 1);
-                sparse->ndata = sparse->nir;
-                data_type = matvar->data_type;
-                if ( matvar->isComplex ) {
-                    mat_complex_split_t *complex_data;
 
-                    complex_data = NEW(mat_complex_split_t);
-                    if ( complex_data != NULL ) {
-                        complex_data->Re = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
-                        complex_data->Im = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
-                        sparse->data     = complex_data;
-                        if ( complex_data->Re != NULL && complex_data->Im != NULL ) {
+                TRY {
+                    complex_data->Re = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
+                    complex_data->Im = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
+                    sparse->data     = complex_data;
+                } CATCH( complex_data->Re == NULL || complex_data->Im == NULL ) {
+                    DELETE(complex_data);
+                    DELETE_ARRAY(sparse->jc);
+                    DELETE_ARRAY(sparse->ir);
+                    DELETE_ARRAY(matvar->data);
+                    matvar->data = NULL;
+                    V_END(Mat_Critical("Memory allocation failure"));
+                }
 #if defined(EXTENDED_SPARSE)
-                            switch ( data_type ) {
-                                case MAT_T_DOUBLE:
-                                    ReadDoubleData(mat, (double*)complex_data->Re,
-                                        data_type, sparse->ndata);
-                                    ReadDoubleData(mat, &tmp, data_type, 1);
-                                    ReadDoubleData(mat, (double*)complex_data->Im,
-                                        data_type, sparse->ndata);
-                                    ReadDoubleData(mat, &tmp, data_type, 1);
-                                    break;
-                                case MAT_T_SINGLE:
-                                {
-                                    float tmp2;
-                                    ReadSingleData(mat, (float*)complex_data->Re,
-                                        data_type, sparse->ndata);
-                                    ReadSingleData(mat, &tmp2, data_type, 1);
-                                    ReadSingleData(mat, (float*)complex_data->Im,
-                                        data_type, sparse->ndata);
-                                    ReadSingleData(mat, &tmp2, data_type, 1);
-                                    break;
-                                }
-                                case MAT_T_INT32:
-                                {
-                                    mat_int32_t tmp2;
-                                    ReadInt32Data(mat, (mat_int32_t*)complex_data->Re,
-                                        data_type, sparse->ndata);
-                                    ReadInt32Data(mat, &tmp2, data_type, 1);
-                                    ReadInt32Data(mat, (mat_int32_t*)complex_data->Im,
-                                        data_type, sparse->ndata);
-                                    ReadInt32Data(mat, &tmp2, data_type, 1);
-                                    break;
-                                }
-                                case MAT_T_INT16:
-                                {
-                                    mat_int16_t tmp2;
-                                    ReadInt16Data(mat, (mat_int16_t*)complex_data->Re,
-                                        data_type, sparse->ndata);
-                                    ReadInt16Data(mat, &tmp2, data_type, 1);
-                                    ReadInt16Data(mat, (mat_int16_t*)complex_data->Im,
-                                        data_type, sparse->ndata);
-                                    ReadInt16Data(mat, &tmp2, data_type, 1);
-                                    break;
-                                }
-                                case MAT_T_UINT16:
-                                {
-                                    mat_uint16_t tmp2;
-                                    ReadUInt16Data(mat, (mat_uint16_t*)complex_data->Re,
-                                        data_type, sparse->ndata);
-                                    ReadUInt16Data(mat, &tmp2, data_type, 1);
-                                    ReadUInt16Data(mat, (mat_uint16_t*)complex_data->Im,
-                                        data_type, sparse->ndata);
-                                    ReadUInt16Data(mat, &tmp2, data_type, 1);
-                                    break;
-                                }
-                                case MAT_T_UINT8:
-                                {
-                                    mat_uint8_t tmp2;
-                                    ReadUInt8Data(mat, (mat_uint8_t*)complex_data->Re,
-                                        data_type, sparse->ndata);
-                                    ReadUInt8Data(mat, &tmp2, data_type, 1);
-                                    ReadUInt8Data(mat, (mat_uint8_t*)complex_data->Im,
-                                        data_type, sparse->ndata);
-                                    ReadUInt8Data(mat, &tmp2, data_type, 1);
-                                    break;
-                                }
-                                default:
-                                    DELETE_ARRAY(complex_data->Re);
-                                    DELETE_ARRAY(complex_data->Im);
-                                    DELETE(complex_data);
-                                    DELETE_ARRAY(sparse->jc);
-                                    DELETE_ARRAY(sparse->ir);
-                                    DELETE_ARRAY(matvar->data);
-                                    matvar->data = NULL;
-                                    Mat_Critical("Read4: %d is not a supported data type for ",
-                                        "extended sparse", data_type);
-                                    return;
-                            }
-#else
-                            ReadDoubleData(mat, (double*)complex_data->Re,
-                                data_type, sparse->ndata);
-                            ReadDoubleData(mat, &tmp, data_type, 1);
-                            ReadDoubleData(mat, (double*)complex_data->Im,
-                                data_type, sparse->ndata);
-                            ReadDoubleData(mat, &tmp, data_type, 1);
-#endif
-                        }
-                    }
-                } else {
-                    sparse->data = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
-                    if ( sparse->data != NULL ) {
-#if defined(EXTENDED_SPARSE)
-                        switch ( data_type ) {
-                            case MAT_T_DOUBLE:
-                                ReadDoubleData(mat, (double*)sparse->data,
-                                    data_type, sparse->ndata);
-                                ReadDoubleData(mat, &tmp, data_type, 1);
-                                break;
-                            case MAT_T_SINGLE:
-                            {
-                                float tmp2;
-                                ReadSingleData(mat, (float*)sparse->data,
-                                    data_type, sparse->ndata);
-                                ReadSingleData(mat, &tmp2, data_type, 1);
-                                break;
-                            }
-                            case MAT_T_INT32:
-                            {
-                                mat_int32_t tmp2;
-                                ReadInt32Data(mat, (mat_int32_t*)sparse->data,
-                                    data_type, sparse->ndata);
-                                ReadInt32Data(mat, &tmp2, data_type, 1);
-                                break;
-                            }
-                            case MAT_T_INT16:
-                            {
-                                mat_int16_t tmp2;
-                                ReadInt16Data(mat, (mat_int16_t*)sparse->data,
-                                    data_type, sparse->ndata);
-                                ReadInt16Data(mat, &tmp2, data_type, 1);
-                                break;
-                            }
-                            case MAT_T_UINT16:
-                            {
-                                mat_uint16_t tmp2;
-                                ReadUInt16Data(mat, (mat_uint16_t*)sparse->data,
-                                    data_type, sparse->ndata);
-                                ReadUInt16Data(mat, &tmp2, data_type, 1);
-                                break;
-                            }
-                            case MAT_T_UINT8:
-                            {
-                                mat_uint8_t tmp2;
-                                ReadUInt8Data(mat, (mat_uint8_t*)sparse->data,
-                                    data_type, sparse->ndata);
-                                ReadUInt8Data(mat, &tmp2, data_type, 1);
-                                break;
-                            }
-                            default:
-                                DELETE_ARRAY(sparse->data);
-                                DELETE_ARRAY(sparse->jc);
-                                DELETE_ARRAY(sparse->ir);
-                                DELETE_ARRAY(matvar->data);
-                                matvar->data = NULL;
-                                Mat_Critical("Read4: %d is not a supported data type for ",
-                                    "extended sparse", data_type);
-                                return;
-                        }
-#else
-                        ReadDoubleData(mat, (double*)sparse->data, data_type, sparse->ndata);
+                switch ( data_type ) {
+                    case MAT_T_DOUBLE:
+                        ReadDoubleData(mat, (double*)complex_data->Re,
+                            data_type, sparse->ndata);
                         ReadDoubleData(mat, &tmp, data_type, 1);
-#endif
-                    } else {
+                        ReadDoubleData(mat, (double*)complex_data->Im,
+                            data_type, sparse->ndata);
+                        ReadDoubleData(mat, &tmp, data_type, 1);
+                        break;
+                    case MAT_T_SINGLE:
+                    {
+                        float tmp2;
+                        ReadSingleData(mat, (float*)complex_data->Re,
+                            data_type, sparse->ndata);
+                        ReadSingleData(mat, &tmp2, data_type, 1);
+                        ReadSingleData(mat, (float*)complex_data->Im,
+                            data_type, sparse->ndata);
+                        ReadSingleData(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    case MAT_T_INT32:
+                    {
+                        mat_int32_t tmp2;
+                        ReadInt32Data(mat, (mat_int32_t*)complex_data->Re,
+                            data_type, sparse->ndata);
+                        ReadInt32Data(mat, &tmp2, data_type, 1);
+                        ReadInt32Data(mat, (mat_int32_t*)complex_data->Im,
+                            data_type, sparse->ndata);
+                        ReadInt32Data(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    case MAT_T_INT16:
+                    {
+                        mat_int16_t tmp2;
+                        ReadInt16Data(mat, (mat_int16_t*)complex_data->Re,
+                            data_type, sparse->ndata);
+                        ReadInt16Data(mat, &tmp2, data_type, 1);
+                        ReadInt16Data(mat, (mat_int16_t*)complex_data->Im,
+                            data_type, sparse->ndata);
+                        ReadInt16Data(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    case MAT_T_UINT16:
+                    {
+                        mat_uint16_t tmp2;
+                        ReadUInt16Data(mat, (mat_uint16_t*)complex_data->Re,
+                            data_type, sparse->ndata);
+                        ReadUInt16Data(mat, &tmp2, data_type, 1);
+                        ReadUInt16Data(mat, (mat_uint16_t*)complex_data->Im,
+                            data_type, sparse->ndata);
+                        ReadUInt16Data(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    case MAT_T_UINT8:
+                    {
+                        mat_uint8_t tmp2;
+                        ReadUInt8Data(mat, (mat_uint8_t*)complex_data->Re,
+                            data_type, sparse->ndata);
+                        ReadUInt8Data(mat, &tmp2, data_type, 1);
+                        ReadUInt8Data(mat, (mat_uint8_t*)complex_data->Im,
+                            data_type, sparse->ndata);
+                        ReadUInt8Data(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    default:
+                        DELETE_ARRAY(complex_data->Re);
+                        DELETE_ARRAY(complex_data->Im);
+                        DELETE(complex_data);
                         DELETE_ARRAY(sparse->jc);
                         DELETE_ARRAY(sparse->ir);
                         DELETE_ARRAY(matvar->data);
                         matvar->data = NULL;
-                        Mat_Critical("Memory allocation failure");
-                        return;
-                    }
+                        V_END(Mat_Critical("Read4: %d is not a supported data type for ",
+                              "extended sparse", data_type));
                 }
-                break;
+#else
+                ReadDoubleData(mat, (double*)complex_data->Re,
+                    data_type, sparse->ndata);
+                ReadDoubleData(mat, &tmp, data_type, 1);
+                ReadDoubleData(mat, (double*)complex_data->Im,
+                    data_type, sparse->ndata);
+                ReadDoubleData(mat, &tmp, data_type, 1);
+#endif
+            } else {
+                TRY {
+                    sparse->data = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
+                } CATCH( sparse->data == NULL ) {
+                    DELETE_ARRAY(sparse->jc);
+                    DELETE_ARRAY(sparse->ir);
+                    DELETE_ARRAY(matvar->data);
+                    matvar->data = NULL;
+                    V_END(Mat_Critical("Memory allocation failure"));
+                }
+#if defined(EXTENDED_SPARSE)
+                switch ( data_type ) {
+                    case MAT_T_DOUBLE:
+                        ReadDoubleData(mat, (double*)sparse->data,
+                            data_type, sparse->ndata);
+                        ReadDoubleData(mat, &tmp, data_type, 1);
+                        break;
+                    case MAT_T_SINGLE:
+                    {
+                        float tmp2;
+                        ReadSingleData(mat, (float*)sparse->data,
+                            data_type, sparse->ndata);
+                        ReadSingleData(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    case MAT_T_INT32:
+                    {
+                        mat_int32_t tmp2;
+                        ReadInt32Data(mat, (mat_int32_t*)sparse->data,
+                            data_type, sparse->ndata);
+                        ReadInt32Data(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    case MAT_T_INT16:
+                    {
+                        mat_int16_t tmp2;
+                        ReadInt16Data(mat, (mat_int16_t*)sparse->data,
+                            data_type, sparse->ndata);
+                        ReadInt16Data(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    case MAT_T_UINT16:
+                    {
+                        mat_uint16_t tmp2;
+                        ReadUInt16Data(mat, (mat_uint16_t*)sparse->data,
+                            data_type, sparse->ndata);
+                        ReadUInt16Data(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    case MAT_T_UINT8:
+                    {
+                        mat_uint8_t tmp2;
+                        ReadUInt8Data(mat, (mat_uint8_t*)sparse->data,
+                            data_type, sparse->ndata);
+                        ReadUInt8Data(mat, &tmp2, data_type, 1);
+                        break;
+                    }
+                    default:
+                        DELETE_ARRAY(sparse->data);
+                        DELETE_ARRAY(sparse->jc);
+                        DELETE_ARRAY(sparse->ir);
+                        DELETE_ARRAY(matvar->data);
+                        matvar->data = NULL;
+                        V_END(Mat_Critical("Read4: %d is not a supported data type for ",
+                                 "extended sparse", data_type));
+                }
+#else
+                ReadDoubleData(mat, (double*)sparse->data, data_type, sparse->ndata);
+                ReadDoubleData(mat, &tmp, data_type, 1);
+#endif
             }
+            break;
+        }
         default:
-            Mat_Critical("MAT V4 data type error");
-            return;
+            V_END(Mat_Critical("MAT V4 data type error"));
     }
 
     return;
@@ -751,16 +787,16 @@ Mat_VarReadNextInfo4(mat_t *mat)
     } endian;
 
     if ( mat == NULL || mat->fp == NULL )
-        return NULL;
+        END(Mat_Critical("Bad mat descriptor"));
     else if ( NULL == (matvar = Mat_VarCalloc()) )
-        return NULL;
+        END(Mat_Critical("Memory allocation failure"));
 
-    matvar->internal->fp   = mat;
-    matvar->internal->fpos = ftell((FILE*)mat->fp);
-    if ( matvar->internal->fpos == -1L ) {
+    TRY {
+        matvar->internal->fp   = mat;
+        matvar->internal->fpos = ftell((FILE*)mat->fp);
+    } CATCH ( matvar->internal->fpos == -1L ) {
         Mat_VarFree(matvar);
-        Mat_Critical("Couldn't determine file position");
-        return NULL;
+        END(Mat_Critical("Couldn't determine file position"));
     }
 
     err = fread(&tmp,sizeof(int),1,(FILE*)mat->fp);
@@ -775,7 +811,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
     if ( tmp < 0 || tmp > 4052 ) {
         if ( Mat_int32Swap(&tmp) > 4052 ) {
             Mat_VarFree(matvar);
-            return NULL;
+            END(Mat_Critical("Bad data descriptor"));
         }
     }
 
@@ -799,12 +835,12 @@ Mat_VarReadNextInfo4(mat_t *mat)
         default:
             /* VAX, Cray, or bogus */
             Mat_VarFree(matvar);
-            return NULL;
+            END(Mat_Critical("Wrong/Unsupported floating point format"));
     }
     /* O must be zero */
     if ( 0 != O ) {
         Mat_VarFree(matvar);
-        return NULL;
+        END(Mat_Critical("Bad data descriptor"));
     }
     /* Convert the V4 data type */
     switch ( data_type ) {
@@ -828,7 +864,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
             break;
         default:
             Mat_VarFree(matvar);
-            return NULL;
+            END(Mat_Critical("Wrong data type"));
     }
     switch ( class_type ) {
         case 0:
@@ -842,69 +878,82 @@ Mat_VarReadNextInfo4(mat_t *mat)
             break;
         default:
             Mat_VarFree(matvar);
-            return NULL;
+            END(Mat_Critical("Wrong class type"));
     }
     matvar->rank = 2;
-    matvar->dims = NEW_ARRAY(size_t,2);
-    if ( NULL == matvar->dims ) {
+    TRY {
+        matvar->dims = NEW_ARRAY(size_t,2);
+    } CATCH ( NULL == matvar->dims ) {
         Mat_VarFree(matvar);
-        return NULL;
-    }
-    err = fread(&tmp,sizeof(int),1,(FILE*)mat->fp);
-    if ( mat->byteswap )
-        Mat_int32Swap(&tmp);
-    matvar->dims[0] = tmp;
-    if ( !err ) {
-        Mat_VarFree(matvar);
-        return NULL;
-    }
-    err = fread(&tmp,sizeof(int),1,(FILE*)mat->fp);
-    if ( mat->byteswap )
-        Mat_int32Swap(&tmp);
-    matvar->dims[1] = tmp;
-    if ( !err ) {
-        Mat_VarFree(matvar);
-        return NULL;
+        END(Mat_Critical("Memory allocation failure"));
     }
 
-    err = fread(&(matvar->isComplex),sizeof(int),1,(FILE*)mat->fp);
-    if ( !err ) {
+    TRY {
+        err = fread(&tmp,sizeof(int),1,(FILE*)mat->fp);
+        if ( mat->byteswap )
+            Mat_int32Swap(&tmp);
+        matvar->dims[0] = tmp;
+    } CATCH ( !err ) {
         Mat_VarFree(matvar);
-        return NULL;
+        END(Mat_Critical("Couldn't read data from file"));
     }
-    err = fread(&tmp,sizeof(int),1,(FILE*)mat->fp);
-    if ( !err ) {
+
+    TRY {
+        err = fread(&tmp,sizeof(int),1,(FILE*)mat->fp);
+        if ( mat->byteswap )
+            Mat_int32Swap(&tmp);
+        matvar->dims[1] = tmp;
+    } CATCH( !err ) {
         Mat_VarFree(matvar);
-        return NULL;
+        END(Mat_Critical("Couldn't read data from file"));
     }
-    if ( mat->byteswap )
-        Mat_int32Swap(&tmp);
+
+    TRY {
+        err = fread(&(matvar->isComplex),sizeof(int),1,(FILE*)mat->fp);
+        //  No byte swap here. This is stange. TODO: POSSIBLE BUG.
+    } CATCH( !err ) {
+        Mat_VarFree(matvar);
+        END(Mat_Critical("Couldn't read data from file"));
+    }
+
+    TRY {
+        err = fread(&tmp,sizeof(int),1,(FILE*)mat->fp);
+        if ( mat->byteswap )
+            Mat_int32Swap(&tmp);
+    } CATCH( !err ) {
+        Mat_VarFree(matvar);
+        END(Mat_Critical("Couldn't read data from file"));
+    }
     /* Check that the length of the variable name is at least 1 */
     if ( tmp < 1 ) {
         Mat_VarFree(matvar);
-        return NULL;
+        END(Mat_Critical("Length of variable name must be at least 1"));
     }
-    matvar->name = NEW_ARRAY(char,tmp);
-    if ( NULL == matvar->name ) {
+
+    TRY {
+        matvar->name = NEW_ARRAY(char,tmp);
+    } CATCH ( NULL == matvar->name ) {
         Mat_VarFree(matvar);
-        return NULL;
+        END(Mat_Critical("Memory allocation failure"));
     }
-    err = fread(matvar->name,1,tmp,(FILE*)mat->fp);
-    if ( !err ) {
+
+    TRY {
+        err = fread(matvar->name,1,tmp,(FILE*)mat->fp);
+    } CATCH( !err ) {
         Mat_VarFree(matvar);
-        return NULL;
+        END(Mat_Critical("Couldn't read data from file"));
     }
 
     matvar->internal->datapos = ftell((FILE*)mat->fp);
     if ( matvar->internal->datapos == -1L ) {
         Mat_VarFree(matvar);
-        Mat_Critical("Couldn't determine file position");
-        return NULL;
+        END(Mat_Critical("Couldn't determine file position"));
     }
     nBytes = matvar->dims[0]*matvar->dims[1]*Mat_SizeOf(matvar->data_type);
     if ( matvar->isComplex )
         nBytes *= 2;
     (void)fseek((FILE*)mat->fp,nBytes,SEEK_CUR);
+    //  No check here, TODO: POSSIBLE BUG.
 
     return matvar;
 }

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -86,7 +86,7 @@ Mat_Create4(const char* matname)
     if ( !fp )
         return NULL;
 
-    mat = (mat_t*)malloc(sizeof(*mat));
+    mat = NEW(mat_t);
     if ( NULL == mat ) {
         fclose(fp);
         Mat_Critical("Couldn't allocate memory for the MAT file");
@@ -299,10 +299,10 @@ Read4(mat_t *mat,matvar_t *matvar)
             if ( matvar->isComplex ) {
                 mat_complex_split_t *complex_data;
 
-                complex_data = (mat_complex_split_t*)malloc(sizeof(*complex_data));
+                complex_data = NEW(mat_complex_split_t);
                 if ( complex_data != NULL ) {
-                    complex_data->Re = malloc(matvar->nbytes);
-                    complex_data->Im = malloc(matvar->nbytes);
+                    complex_data->Re = NEW_ARRAY(char,matvar->nbytes);
+                    complex_data->Im = NEW_ARRAY(char,matvar->nbytes);
                     matvar->data     = complex_data;
                     if ( complex_data->Re != NULL && complex_data->Im != NULL ) {
                         ReadDoubleData(mat, (double*)complex_data->Re, matvar->data_type, N);
@@ -310,7 +310,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                     }
                 }
             } else {
-                matvar->data = malloc(matvar->nbytes);
+                matvar->data = NEW_ARRAY(char,matvar->nbytes);
                 if ( matvar->data != NULL )
                     ReadDoubleData(mat, (double*)matvar->data, matvar->data_type, N);
             }
@@ -320,7 +320,7 @@ Read4(mat_t *mat,matvar_t *matvar)
         case MAT_C_CHAR:
             matvar->data_size = 1;
             matvar->nbytes = N;
-            matvar->data = malloc(matvar->nbytes);
+            matvar->data = NEW_ARRAY(char,matvar->nbytes);
             if ( NULL == matvar->data )
                 Mat_Critical("Memory allocation failure");
             else
@@ -329,7 +329,7 @@ Read4(mat_t *mat,matvar_t *matvar)
             break;
         case MAT_C_SPARSE:
             matvar->data_size = sizeof(mat_sparse_t);
-            matvar->data      = malloc(matvar->data_size);
+            matvar->data      = NEW_ARRAY(char,matvar->data_size);
             if ( matvar->data == NULL )
                 Mat_Critical("Memory allocation failure");
             else {
@@ -344,7 +344,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                 sparse = (mat_sparse_t*)matvar->data;
                 sparse->nir = matvar->dims[0] - 1;
                 sparse->nzmax = sparse->nir;
-                sparse->ir = (mat_int32_t*)malloc(sparse->nir*sizeof(mat_int32_t));
+                sparse->ir = NEW_ARRAY(mat_int32_t,sparse->nir);
                 if ( sparse->ir != NULL ) {
                     ReadInt32Data(mat, sparse->ir, data_type, sparse->nir);
                     for ( i = 0; i < sparse->nir; i++ )
@@ -386,10 +386,10 @@ Read4(mat_t *mat,matvar_t *matvar)
                     return;
                 }
                 sparse->njc = (int)matvar->dims[1] + 1;
-                sparse->jc = (mat_int32_t*)malloc(sparse->njc*sizeof(mat_int32_t));
+                sparse->jc = NEW_ARRAY(mat_int32_t,sparse->njc);
                 if ( sparse->jc != NULL ) {
                     mat_int32_t *jc;
-                    jc = (mat_int32_t*)malloc(sparse->nir*sizeof(mat_int32_t));
+                    jc = NEW_ARRAY(mat_int32_t,sparse->nir);
                     if ( jc != NULL ) {
                         int j = 0;
                         sparse->jc[0] = 0;
@@ -423,10 +423,10 @@ Read4(mat_t *mat,matvar_t *matvar)
                 if ( matvar->isComplex ) {
                     mat_complex_split_t *complex_data;
 
-                    complex_data = (mat_complex_split_t*)malloc(sizeof(*complex_data));
+                    complex_data = NEW(mat_complex_split_t);
                     if ( complex_data != NULL ) {
-                        complex_data->Re = malloc(sparse->ndata*Mat_SizeOf(data_type));
-                        complex_data->Im = malloc(sparse->ndata*Mat_SizeOf(data_type));
+                        complex_data->Re = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
+                        complex_data->Im = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
                         sparse->data     = complex_data;
                         if ( complex_data->Re != NULL && complex_data->Im != NULL ) {
 #if defined(EXTENDED_SPARSE)
@@ -517,7 +517,7 @@ Read4(mat_t *mat,matvar_t *matvar)
                         }
                     }
                 } else {
-                    sparse->data = malloc(sparse->ndata*Mat_SizeOf(data_type));
+                    sparse->data = NEW_ARRAY(char,sparse->ndata*Mat_SizeOf(data_type));
                     if ( sparse->data != NULL ) {
 #if defined(EXTENDED_SPARSE)
                         switch ( data_type ) {
@@ -845,7 +845,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
             return NULL;
     }
     matvar->rank = 2;
-    matvar->dims = (size_t*)malloc(2*sizeof(*matvar->dims));
+    matvar->dims = NEW_ARRAY(size_t,2);
     if ( NULL == matvar->dims ) {
         Mat_VarFree(matvar);
         return NULL;
@@ -884,7 +884,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
         Mat_VarFree(matvar);
         return NULL;
     }
-    matvar->name = (char*)malloc(tmp);
+    matvar->name = NEW_ARRAY(char,tmp);
     if ( NULL == matvar->name ) {
         Mat_VarFree(matvar);
         return NULL;

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -101,7 +101,7 @@ Mat_Create4(const char* matname)
     mat->bof           = 0;
     mat->next_index    = 0;
     mat->refs_id       = -1;
-    mat->filename      = strdup_printf("%s",matname);
+    mat->filename      = STRDUP(matname);
     mat->mode          = 0;
 
     Mat_Rewind(mat);

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -511,7 +511,7 @@ Mat_Create5(const char *matname,const char *hdr_str)
 
     t = time(NULL);
     mat->fp       = fp;
-    mat->filename = strdup_printf("%s",matname);
+    mat->filename = STRDUP(matname);
     mat->mode     = MAT_ACC_RDWR;
     mat->byteswap = 0;
     mat->header   = NEW_ARRAY(char,128);
@@ -2147,7 +2147,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
         for ( i = 0; i < nmemb; i++ ) {
             for ( j = 0; j < nfields; j++ ) {
                 fields[i*nfields+j] = Mat_VarCalloc();
-                fields[i*nfields+j]->name = strdup(matvar->internal->fieldnames[j]);
+                fields[i*nfields+j]->name = STRDUP(matvar->internal->fieldnames[j]);
             }
         }
 
@@ -2323,7 +2323,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
         for ( i = 0; i < nmemb; i++ ) {
             for ( j = 0; j < nfields; j++ ) {
                 fields[i*nfields+j] = Mat_VarCalloc();
-                fields[i*nfields+j]->name = strdup(matvar->internal->fieldnames[j]);
+                fields[i*nfields+j]->name = STRDUP(matvar->internal->fieldnames[j]);
             }
         }
 

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -518,7 +518,7 @@ Mat_H5ReadDatasetInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
 #if 0
     matvar->fp = mat;
     name_len = H5Gget_objname_by_idx(fid,mat->next_index,NULL,0);
-    matvar->name = malloc(1+name_len);
+    matvar->name = NEW(char,1+name_len);
     if ( matvar->name ) {
         name_len = H5Gget_objname_by_idx(fid,mat->next_index,
                                          matvar->name,1+name_len);
@@ -530,7 +530,7 @@ Mat_H5ReadDatasetInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
     /* Get the HDF5 name of the variable */
     name_len = H5Iget_name(dset_id,NULL,0);
     if ( name_len > 0 ) {
-        matvar->internal->hdf5_name = (char*)malloc(name_len+1);
+        matvar->internal->hdf5_name = NEW_ARRAY(char,name_len+1);
         (void)H5Iget_name(dset_id,matvar->internal->hdf5_name,name_len+1);
     } else {
         /* Can not get an internal name, so leave the identifier open */
@@ -539,7 +539,7 @@ Mat_H5ReadDatasetInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
 
     space_id     = H5Dget_space(dset_id);
     matvar->rank = H5Sget_simple_extent_ndims(space_id);
-    matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+    matvar->dims = NEW_ARRAY(size_t,matvar->rank);
     if ( NULL != matvar->dims ) {
         int k;
         H5Sget_simple_extent_dims(space_id,dims,NULL);
@@ -595,11 +595,11 @@ Mat_H5ReadDatasetInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
             ncells *= matvar->dims[i];
         matvar->data_size = sizeof(matvar_t**);
         matvar->nbytes    = ncells*matvar->data_size;
-        matvar->data      = malloc(matvar->nbytes);
+        matvar->data      = NEW_ARRAY(char,matvar->nbytes);
         cells = (matvar_t**)matvar->data;
 
         if ( ncells ) {
-            ref_ids = (hobj_ref_t*)malloc(ncells*sizeof(*ref_ids));
+            ref_ids = NEW_ARRAY(hobj_ref_t,ncells);
             H5Dread(dset_id,H5T_STD_REF_OBJ,H5S_ALL,H5S_ALL,H5P_DEFAULT,
                     ref_ids);
             for ( i = 0; i < ncells; i++ ) {
@@ -628,7 +628,7 @@ Mat_H5ReadDatasetInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
             space_id = H5Aget_space(attr_id);
             (void)H5Sget_simple_extent_dims(space_id,&nfields,NULL);
             field_id = H5Aget_type(attr_id);
-            fieldnames_vl = (hvl_t*)malloc(nfields*sizeof(*fieldnames_vl));
+            fieldnames_vl = NEW_ARRAY(hvl_t,nfields);
             H5Aread(attr_id,field_id,fieldnames_vl);
 
             matvar->internal->num_fields = nfields;
@@ -665,7 +665,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
 #if 0
     matvar->fp = mat;
     name_len = H5Gget_objname_by_idx(fid,mat->next_index,NULL,0);
-    matvar->name = malloc(1+name_len);
+    matvar->name = NEW_ARRAY(char,1+name_len);
     if ( matvar->name ) {
         name_len = H5Gget_objname_by_idx(fid,mat->next_index,
                                          matvar->name,1+name_len);
@@ -677,7 +677,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
     /* Get the HDF5 name of the variable */
     name_len = H5Iget_name(dset_id,NULL,0);
     if ( name_len > 0 ) {
-        matvar->internal->hdf5_name = (char*)malloc(name_len+1);
+        matvar->internal->hdf5_name = NEW_ARRAY(char,name_len+1);
         (void)H5Iget_name(dset_id,matvar->internal->hdf5_name,name_len+1);
     } else {
         /* Can not get an internal name, so leave the identifier open */
@@ -706,7 +706,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
         matvar->class_type = MAT_C_SPARSE;
 
         matvar->rank = 2;
-        matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+        matvar->dims = NEW_ARRAY(size_t,matvar->rank);
         if (matvar->dims == NULL) {
             Mat_Critical("Error allocating memory for matvar->dims");
             return;
@@ -743,12 +743,12 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
         space_id = H5Aget_space(attr_id);
         (void)H5Sget_simple_extent_dims(space_id,&nfields,NULL);
         field_id = H5Aget_type(attr_id);
-        fieldnames_vl = (hvl_t*)malloc(nfields*sizeof(*fieldnames_vl));
+        fieldnames_vl = NEW_ARRAY(hvl_t,nfields);
         H5Aread(attr_id,field_id,fieldnames_vl);
 
         matvar->internal->num_fields = nfields;
         matvar->internal->fieldnames =
-            (char**)malloc(nfields*sizeof(*matvar->internal->fieldnames));
+            NEW_ARRAY(char*,nfields);
         for ( k = 0; k < nfields; k++ ) {
             matvar->internal->fieldnames[k] = (char*)calloc(fieldnames_vl[k].len+1,1);
             memcpy(matvar->internal->fieldnames[k],fieldnames_vl[k].p,
@@ -808,7 +808,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                 attr_id = H5Aopen_by_name(field_id,".","MATLAB_class",H5P_DEFAULT,H5P_DEFAULT);
                 H5Aclose(attr_id);
                 matvar->rank    = 2;
-                matvar->dims    = (size_t*)malloc(2*sizeof(*matvar->dims));
+                matvar->dims    = NEW_ARRAY(size_t,2);
                 if (matvar->dims == NULL) {
                     H5Tclose(field_type_id);
                     H5Dclose(field_id);
@@ -821,7 +821,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
             } else {
                 space_id     = H5Dget_space(field_id);
                 matvar->rank = H5Sget_simple_extent_ndims(space_id);
-                matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+                matvar->dims = NEW_ARRAY(size_t,matvar->rank);
                 if (matvar->dims == NULL) {
                     H5Tclose(field_type_id);
                     H5Dclose(field_id);
@@ -841,7 +841,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
         } else {
             /* Structure should be a scalar */
             matvar->rank    = 2;
-            matvar->dims    = (size_t*)malloc(2*sizeof(*matvar->dims));
+            matvar->dims    = NEW_ARRAY(size_t,2);
             if (matvar->dims == NULL) {
                 H5Tclose(field_type_id);
                 H5Dclose(field_id);
@@ -858,7 +858,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
         /* Structure should be a scalar */
         numel = 1;
         matvar->rank    = 2;
-        matvar->dims    = (size_t*)malloc(2*sizeof(*matvar->dims));
+        matvar->dims    = NEW_ARRAY(size_t,2);
         if (matvar->dims == NULL) {
             Mat_Critical("Error allocating memory for matvar->dims");
             return;
@@ -870,7 +870,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
     if ( numel < 1 || nfields < 1 )
         return;
 
-    fields = (matvar_t**)malloc(nfields*numel*sizeof(*fields));
+    fields = NEW_ARRAY(matvar_t*,nfields*numel);
     matvar->data = fields;
     matvar->data_size = sizeof(*fields);
     matvar->nbytes    = nfields*numel*matvar->data_size;
@@ -884,7 +884,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                 field_id = H5Dopen(dset_id,matvar->internal->fieldnames[k],
                                    H5P_DEFAULT);
                 if ( !fields_are_variables ) {
-                    hobj_ref_t *ref_ids = (hobj_ref_t*)malloc(numel*sizeof(*ref_ids));
+                    hobj_ref_t *ref_ids = NEW_ARRAY(hobj_ref_t,numel);
                     H5Dread(field_id,H5T_STD_REF_OBJ,H5S_ALL,H5S_ALL,
                             H5P_DEFAULT,ref_ids);
                     for ( l = 0; l < numel; l++ ) {
@@ -897,7 +897,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                         name_len = H5Iget_name(field_id,NULL,0);
                         if ( name_len > 0 ) {
                             fields[l*nfields+k]->internal->hdf5_name =
-                                (char*)malloc(name_len+1);
+                                NEW_ARRAY(char,name_len+1);
                             (void)H5Iget_name(field_id,
                                 fields[l*nfields+k]->internal->hdf5_name,
                                 name_len+1);
@@ -992,7 +992,7 @@ Mat_H5ReadNextReferenceInfo(hid_t ref_id,matvar_t *matvar,mat_t *mat)
 #if 0
             /* Get the HDF5 name of the variable */
             name_len = H5Iget_name(dset_id,NULL,0);
-            matvar->hdf5_name = malloc(name_len+1);
+            matvar->hdf5_name = NEW_ARRAY(char,name_len+1);
             (void)H5Iget_name(dset_id,matvar->hdf5_name,name_len);
             printf("%s\n",matvar->hdf5_name);
 #endif
@@ -1000,7 +1000,7 @@ Mat_H5ReadNextReferenceInfo(hid_t ref_id,matvar_t *matvar,mat_t *mat)
             /* Get the rank and dimensions of the data */
             space_id = H5Dget_space(dset_id);
             matvar->rank = H5Sget_simple_extent_ndims(space_id);
-            matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+            matvar->dims = NEW_ARRAY(size_t,matvar->rank);
             if ( NULL == matvar->dims ) {
                 H5Sclose(space_id);
                 break;
@@ -1054,12 +1054,12 @@ Mat_H5ReadNextReferenceInfo(hid_t ref_id,matvar_t *matvar,mat_t *mat)
                     ncells *= matvar->dims[i];
                 matvar->data_size = sizeof(matvar_t**);
                 matvar->nbytes    = ncells*matvar->data_size;
-                matvar->data      = malloc(matvar->nbytes);
+                matvar->data      = NEW_ARRAY(char,matvar->nbytes);
                 cells = (matvar_t**)matvar->data;
 
                 if ( ncells > 0 ) {
                     hobj_ref_t *ref_ids;
-                    ref_ids = (hobj_ref_t*)malloc(ncells*sizeof(*ref_ids));
+                    ref_ids = NEW_ARRAY(hobj_ref_t,ncells);
                     H5Dread(dset_id,H5T_STD_REF_OBJ,H5S_ALL,H5S_ALL,H5P_DEFAULT,
                             ref_ids);
                     for ( i = 0; i < ncells; i++ ) {
@@ -1088,12 +1088,11 @@ Mat_H5ReadNextReferenceInfo(hid_t ref_id,matvar_t *matvar,mat_t *mat)
                     space_id = H5Aget_space(attr_id);
                     (void)H5Sget_simple_extent_dims(space_id,&nfields,NULL);
                     field_id = H5Aget_type(attr_id);
-                    fieldnames_vl = (hvl_t*)malloc(nfields*sizeof(*fieldnames_vl));
+                    fieldnames_vl = NEW_ARRAY(hvl_t,nfields);
                     H5Aread(attr_id,field_id,fieldnames_vl);
 
                     matvar->internal->num_fields = nfields;
-                    matvar->internal->fieldnames =
-                        (char**)malloc(nfields*sizeof(*matvar->internal->fieldnames));
+                    matvar->internal->fieldnames = NEW_ARRAY(char*,nfields);
                     for ( i = 0; i < nfields; i++ ) {
                         matvar->internal->fieldnames[i] =
                             (char*)calloc(fieldnames_vl[i].len+1,1);
@@ -1182,7 +1181,7 @@ Mat_H5ReadNextReferenceData(hid_t ref_id,matvar_t *matvar,mat_t *mat)
             dset_id = ref_id;
 
             if ( !matvar->isComplex ) {
-                matvar->data      = malloc(matvar->nbytes);
+                matvar->data      = NEW_ARRAY(char,matvar->nbytes);
                 if ( NULL != matvar->data ) {
                     H5Dread(dset_id,data_type_id,H5S_ALL,H5S_ALL,H5P_DEFAULT,
                             matvar->data);
@@ -1191,9 +1190,9 @@ Mat_H5ReadNextReferenceData(hid_t ref_id,matvar_t *matvar,mat_t *mat)
                 mat_complex_split_t *complex_data;
                 hid_t h5_complex_base,h5_complex;
 
-                complex_data     = (mat_complex_split_t*)malloc(sizeof(*complex_data));
-                complex_data->Re = malloc(matvar->nbytes);
-                complex_data->Im = malloc(matvar->nbytes);
+                complex_data     = NEW(mat_complex_split_t);
+                complex_data->Re = NEW_ARRAY(char,matvar->nbytes);
+                complex_data->Im = NEW_ARRAY(char,matvar->nbytes);
 
                 h5_complex_base = data_type_id;
                 h5_complex      = H5Tcreate(H5T_COMPOUND,
@@ -1320,7 +1319,7 @@ Mat_VarWriteCell73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id)
             for ( k = 0; k < matvar->rank; k++ )
                 perm_dims[k] = matvar->dims[matvar->rank-k-1];
 
-            refs = (hobj_ref_t*)malloc(nmemb*sizeof(*refs));
+            refs = NEW_ARRAY(hobj_ref_t,nmemb);
             mspace_id=H5Screate_simple(matvar->rank,perm_dims,NULL);
             dset_id = H5Dcreate(id,name,H5T_STD_REF_OBJ,mspace_id,
                                 H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
@@ -1948,7 +1947,7 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id)
         nfields = matvar->internal->num_fields;
         if ( nfields ) {
             str_type_id = H5Tcopy(H5T_C_S1);
-            fieldnames = (hvl_t*)malloc(nfields*sizeof(*fieldnames));
+            fieldnames = NEW_ARRAY(hvl_t,nfields);
             fields     = (matvar_t**)matvar->data;
             for ( k = 0; k < nfields; k++ ) {
                 fieldnames[k].len =
@@ -1999,7 +1998,7 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id)
                 return 0;
             }
 
-            fieldnames = (hvl_t*)malloc(nfields*sizeof(*fieldnames));
+            fieldnames = NEW_ARRAY(hvl_t,nfields);
             fields     = (matvar_t**)matvar->data;
             for ( k = 0; k < nfields; k++ ) {
                 fieldnames[k].len =
@@ -2039,9 +2038,9 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id)
                     hobj_ref_t **refs;
                     int l;
 
-                    refs = (hobj_ref_t**)malloc(nfields*sizeof(*refs));
+                    refs = NEW_ARRAY(hobj_ref_t*,nfields);
                     for ( l = 0; l < nfields; l++ )
-                        refs[l] = (hobj_ref_t*)malloc(nmemb*sizeof(*refs[l]));
+                        refs[l] = NEW_ARRAY(hobj_ref_t,nmemb);
 
                     for ( k = 0; k < nmemb; k++ ) {
                         for ( l = 0; l < nfields; l++ ) {
@@ -2163,7 +2162,7 @@ Mat_Create73(const char *matname,const char *hdr_str)
 
     (void)fseek(fp,0,SEEK_SET);
 
-    mat = (mat_t*)malloc(sizeof(*mat));
+    mat = NEW(mat_t);
     if ( mat == NULL ) {
         fclose(fp);
         return NULL;
@@ -2184,8 +2183,8 @@ Mat_Create73(const char *matname,const char *hdr_str)
     mat->filename = strdup_printf("%s",matname);
     mat->mode     = MAT_ACC_RDWR;
     mat->byteswap = 0;
-    mat->header   = (char*)malloc(128*sizeof(char));
-    mat->subsys_offset = (char*)malloc(8*sizeof(char));
+    mat->header   = NEW_ARRAY(char,128);
+    mat->subsys_offset = NEW_ARRAY(char,8);
     memset(mat->header,' ',128);
     if ( hdr_str == NULL ) {
         err = mat_snprintf(mat->header,116,"MATLAB 7.3 MAT-file, Platform: %s, "
@@ -2212,7 +2211,7 @@ Mat_Create73(const char *matname,const char *hdr_str)
 
     fid = H5Fopen(matname,H5F_ACC_RDWR,H5P_DEFAULT);
 
-    mat->fp = malloc(sizeof(hid_t));
+    mat->fp = NEW(hid_t);
     *(hid_t*)mat->fp = fid;
 
     return mat;
@@ -2274,7 +2273,7 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
             }
 
             if ( !matvar->isComplex ) {
-                matvar->data     = malloc(matvar->nbytes);
+                matvar->data     = NEW_ARRAY(char,matvar->nbytes);
                 if ( NULL != matvar->data ) {
                     H5Dread(dset_id,Mat_class_type_to_hid_t(matvar->class_type),
                             H5S_ALL,H5S_ALL,H5P_DEFAULT,matvar->data);
@@ -2283,9 +2282,9 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                 mat_complex_split_t *complex_data;
                 hid_t h5_complex_base,h5_complex;
 
-                complex_data     = (mat_complex_split_t*)malloc(sizeof(*complex_data));
-                complex_data->Re = malloc(matvar->nbytes);
-                complex_data->Im = malloc(matvar->nbytes);
+                complex_data     = NEW(mat_complex_split_t);
+                complex_data->Re = NEW_ARRAY(char,matvar->nbytes);
+                complex_data->Im = NEW_ARRAY(char,matvar->nbytes);
 
                 h5_complex_base = Mat_class_type_to_hid_t(matvar->class_type);
                 h5_complex      = H5Tcreate(H5T_COMPOUND,
@@ -2321,7 +2320,7 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                 H5Iinc_ref(dset_id);
             }
             if ( matvar->nbytes > 0 ) {
-                matvar->data = malloc(matvar->nbytes);
+                matvar->data = NEW_ARRAY(char,matvar->nbytes);
                 if ( NULL != matvar->data ) {
                     H5Dread(dset_id,Mat_data_type_to_hid_t(matvar->data_type),
                             H5S_ALL,H5S_ALL,H5P_DEFAULT,matvar->data);
@@ -2389,8 +2388,7 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                 space_id = H5Dget_space(sparse_dset_id);
                 H5Sget_simple_extent_dims(space_id,dims,NULL);
                 sparse_data->nir = dims[0];
-                sparse_data->ir = (int*)malloc(sparse_data->nir*
-                                         sizeof(*sparse_data->ir));
+                sparse_data->ir = NEW_ARRAY(int,sparse_data->nir);
                 H5Dread(sparse_dset_id,H5T_NATIVE_INT,
                         H5S_ALL,H5S_ALL,H5P_DEFAULT,sparse_data->ir);
                 H5Sclose(space_id);
@@ -2402,8 +2400,7 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                 space_id = H5Dget_space(sparse_dset_id);
                 H5Sget_simple_extent_dims(space_id,dims,NULL);
                 sparse_data->njc = dims[0];
-                sparse_data->jc = (int*)malloc(sparse_data->njc*
-                                         sizeof(*sparse_data->jc));
+                sparse_data->jc = NEW_ARRAY(int,sparse_data->njc);
                 H5Dread(sparse_dset_id,H5T_NATIVE_INT,
                         H5S_ALL,H5S_ALL,H5P_DEFAULT,sparse_data->jc);
                 H5Sclose(space_id);
@@ -2422,7 +2419,7 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
 
                 ndata_bytes = sparse_data->nzmax*Mat_SizeOf(matvar->data_type);
                 if ( !matvar->isComplex ) {
-                    sparse_data->data  = malloc(ndata_bytes);
+                    sparse_data->data  = NEW_ARRAY(char,ndata_bytes);
                     if ( NULL != sparse_data->data ) {
                         H5Dread(sparse_dset_id,
                                 Mat_data_type_to_hid_t(matvar->data_type),
@@ -2432,9 +2429,9 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                     mat_complex_split_t *complex_data;
                     hid_t h5_complex_base,h5_complex;
 
-                    complex_data     = (mat_complex_split_t*)malloc(sizeof(*complex_data));
-                    complex_data->Re = malloc(ndata_bytes);
-                    complex_data->Im = malloc(ndata_bytes);
+                    complex_data     = NEW(mat_complex_split_t);
+                    complex_data->Re = NEW_ARRAY(char,ndata_bytes);
+                    complex_data->Im = NEW_ARRAY(char,ndata_bytes);
 
                     h5_complex_base = Mat_data_type_to_hid_t(matvar->data_type);
                     h5_complex      = H5Tcreate(H5T_COMPOUND,
@@ -2622,7 +2619,7 @@ Mat_VarReadDataLinear73(mat_t *mat,matvar_t *matvar,void *data,
                 H5Iinc_ref(dset_id);
             }
 
-            points = (hsize_t*)malloc(matvar->rank*dset_edge*sizeof(*points));
+            points = NEW_ARRAY(hsize_t,matvar->rank*dset_edge);
             if ( NULL == points ) {
                 err = -2;
                 break;
@@ -2737,7 +2734,7 @@ Mat_VarReadNextInfoIterate(hid_t fid, const char *name, const H5L_info_t *info, 
         return -1;
 
     matvar->internal->fp = mat;
-    matvar->name = (char*)malloc(1 + strlen(name));
+    matvar->name = NEW_ARRAY(char,1 + strlen(name));
     if ( matvar->name == NULL ) {
         Mat_VarFree(matvar);
         return -1;
@@ -2757,7 +2754,7 @@ Mat_VarReadNextInfoIterate(hid_t fid, const char *name, const H5L_info_t *info, 
             /* Get the HDF5 name of the variable */
             name_len = H5Iget_name(dset_id,NULL,0);
             if ( name_len > 0 ) {
-                matvar->internal->hdf5_name = (char*)malloc(name_len+1);
+                matvar->internal->hdf5_name = NEW_ARRAY(char,name_len+1);
                 (void)H5Iget_name(dset_id,matvar->internal->hdf5_name,
                                   name_len+1);
             } else {
@@ -2767,7 +2764,7 @@ Mat_VarReadNextInfoIterate(hid_t fid, const char *name, const H5L_info_t *info, 
 
             space_id = H5Dget_space(dset_id);
             matvar->rank = H5Sget_simple_extent_ndims(space_id);
-            matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+            matvar->dims = NEW_ARRAY(size_t,matvar->rank);
             if ( NULL != matvar->dims ) {
                 int k;
                 H5Sget_simple_extent_dims(space_id,dims,NULL);
@@ -2824,11 +2821,11 @@ Mat_VarReadNextInfoIterate(hid_t fid, const char *name, const H5L_info_t *info, 
                     ncells *= matvar->dims[i];
                 matvar->data_size = sizeof(matvar_t**);
                 matvar->nbytes    = ncells*matvar->data_size;
-                matvar->data      = malloc(matvar->nbytes);
+                matvar->data      = NEW_ARRAY(char,matvar->nbytes);
                 cells = (matvar_t**)matvar->data;
 
                 if ( ncells ) {
-                    ref_ids = (hobj_ref_t*)malloc(ncells*sizeof(*ref_ids));
+                    ref_ids = NEW_ARRAY(hobj_ref_t,ncells);
                     H5Dread(dset_id,H5T_STD_REF_OBJ,H5S_ALL,H5S_ALL,H5P_DEFAULT,
                             ref_ids);
                     for ( i = 0; i < ncells; i++ ) {
@@ -2859,7 +2856,7 @@ Mat_VarReadNextInfoIterate(hid_t fid, const char *name, const H5L_info_t *info, 
                     space_id = H5Aget_space(attr_id);
                     (void)H5Sget_simple_extent_dims(space_id,&nfields,NULL);
                     field_id = H5Aget_type(attr_id);
-                    fieldnames_vl = (hvl_t*)malloc(nfields*sizeof(*fieldnames_vl));
+                    fieldnames_vl = NEW_ARRAY(hvl_t,nfields);
                     H5Aread(attr_id,field_id,fieldnames_vl);
 
                     matvar->internal->num_fields = nfields;

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -888,7 +888,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                         hid_t ref_id;
                         fields[l*nfields+k] = Mat_VarCalloc();
                         fields[l*nfields+k]->name =
-                            strdup(matvar->internal->fieldnames[k]);
+                            STRDUP(matvar->internal->fieldnames[k]);
                         fields[l*nfields+k]->internal->hdf5_ref=ref_ids[l];
                         /* Get the HDF5 name of the variable */
                         name_len = H5Iget_name(field_id,NULL,0);
@@ -912,7 +912,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                     fields[k] = Mat_VarCalloc();
                     fields[k]->internal->fp   = mat;
                     fields[k]->name =
-                        strdup(matvar->internal->fieldnames[k]);
+                        STRDUP(matvar->internal->fieldnames[k]);
                     Mat_H5ReadDatasetInfo(mat,fields[k],field_id);
                 }
                 H5Dclose(field_id);
@@ -922,7 +922,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                 if ( -1 < field_id ) {
                     fields[k] = Mat_VarCalloc();
                     fields[k]->internal->fp   = mat;
-                    fields[k]->name = strdup(matvar->internal->fieldnames[k]);
+                    fields[k]->name = STRDUP(matvar->internal->fieldnames[k]);
                     Mat_H5ReadGroupInfo(mat,fields[k],field_id);
                     H5Gclose(field_id);
                 }
@@ -2175,7 +2175,7 @@ Mat_Create73(const char *matname,const char *hdr_str)
     mat->refs_id          = -1;
 
     t = time(NULL);
-    mat->filename = strdup_printf("%s",matname);
+    mat->filename = STRDUP(matname);
     mat->mode     = MAT_ACC_RDWR;
     mat->byteswap = 0;
     mat->header   = NEW_ARRAY(char,128);

--- a/src/matio.h
+++ b/src/matio.h
@@ -224,8 +224,6 @@ typedef struct mat_sparse_t {
 EXTERN void Mat_GetLibraryVersion(int *major,int *minor,int *release);
 
 /*     io.c         */
-EXTERN char  *strdup_vprintf(const char *format, va_list ap);
-EXTERN char  *strdup_printf(const char *format, ...);
 EXTERN int    Mat_SetVerbose( int verb, int s );
 EXTERN int    Mat_SetDebug( int d );
 EXTERN void   Mat_Critical( const char *format, ... );
@@ -266,6 +264,7 @@ EXTERN void       Mat_VarFree(matvar_t *matvar);
 EXTERN matvar_t  *Mat_VarGetCell(matvar_t *matvar,int index);
 EXTERN matvar_t **Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,
                       int *edge);
+
 EXTERN matvar_t **Mat_VarGetCellsLinear(matvar_t *matvar,int start,int stride,
                       int edge);
 EXTERN size_t     Mat_VarGetSize(matvar_t *matvar);

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -61,6 +61,12 @@
     #define DELETE(v) delete v
     #define DELETE_ARRAY(v) delete[] v
     #define DELETE_BUFFER(v) DELETE_ARRAY(static_cast<char*>(v))
+    inline char* STRDUP(const char* s) {
+        const unsigned sz = strlen(s)+1;
+        char* str = NEW_ARRAY(char,sz);
+        memcpy(str,s,sz);
+        return str;
+    }
 #else
     #define TRY 
     #define NEW(type) (type*) malloc(sizeof(type))
@@ -70,6 +76,7 @@
     #define DELETE(v) free(v)
     #define DELETE_ARRAY(v) free(v)
     #define DELETE_BUFFER(v) DELETE_ARRAY(v)
+    #define STRDUP strdup
 #endif
 
 /** @if mat_devman

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -52,6 +52,18 @@
 #   define ZLIB_BYTE_PTR(a) ((Bytef *)(a))
 #endif
 
+#ifdef __cplusplus
+    #define TRY try {
+    #define NEW(type) new type
+    #define NEW_ARRAY(type,size) new type[size]
+    #define CATCH(e) } catch(...) 
+#else
+    #define TRY 
+    #define NEW(type) (type*) malloc(sizeof(type))
+    #define NEW_ARRAY(type,size) (type*) malloc(size*sizeof(type))
+    #define CATCH(e) if (e) 
+#endif
+
 /** @if mat_devman
  * @brief Matlab MAT File information
  *

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -53,6 +53,7 @@
 #endif
 
 #ifdef __cplusplus
+    #include <string.h>
     #define TRY try {
     #define NEW(type) new type
     #define NEW_ARRAY(type,size) new type[size]
@@ -67,6 +68,8 @@
         memcpy(str,s,sz);
         return str;
     }
+    #define END(x) x
+    #define V_END(x) x
 #else
     #define TRY 
     #define NEW(type) (type*) malloc(sizeof(type))
@@ -77,6 +80,8 @@
     #define DELETE_ARRAY(v) free(v)
     #define DELETE_BUFFER(v) DELETE_ARRAY(v)
     #define STRDUP strdup
+    #define END(x)    do { x; return NULL; } while(0)
+    #define V_END(x)  do { x; return; } while(0)
 #endif
 
 /** @if mat_devman

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -56,12 +56,20 @@
     #define TRY try {
     #define NEW(type) new type
     #define NEW_ARRAY(type,size) new type[size]
+    #define NEW_BUFFER(size) NEW_ARRAY(char,size)
     #define CATCH(e) } catch(...) 
+    #define DELETE(v) delete v
+    #define DELETE_ARRAY(v) delete[] v
+    #define DELETE_BUFFER(v) DELETE_ARRAY(static_cast<char*>(v))
 #else
     #define TRY 
     #define NEW(type) (type*) malloc(sizeof(type))
     #define NEW_ARRAY(type,size) (type*) malloc(size*sizeof(type))
+    #define NEW_BUFFER(size) NEW_ARRAY(char,size)
     #define CATCH(e) if (e) 
+    #define DELETE(v) free(v)
+    #define DELETE_ARRAY(v) free(v)
+    #define DELETE_BUFFER(v) DELETE_ARRAY(v)
 #endif
 
 /** @if mat_devman

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -68,8 +68,8 @@
         memcpy(str,s,sz);
         return str;
     }
-    #define END(x) x
-    #define V_END(x) x
+    #define END(stmt,retcode) stmt
+    #define V_END(stmt) stmt
 #else
     #define TRY 
     #define NEW(type) (type*) malloc(sizeof(type))
@@ -80,8 +80,8 @@
     #define DELETE_ARRAY(v) free(v)
     #define DELETE_BUFFER(v) DELETE_ARRAY(v)
     #define STRDUP strdup
-    #define END(x)    do { x; return NULL; } while(0)
-    #define V_END(x)  do { x; return; } while(0)
+    #define END(stmt,retcode) do { stmt; return retcode; } while(0)
+    #define V_END(stmt)       do { stmt; return; } while(0)
 #endif
 
 /** @if mat_devman

--- a/src/matvar_cell.c
+++ b/src/matvar_cell.c
@@ -100,7 +100,13 @@ Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,int *edge)
         N *= edge[i];
         I += start[i]*dimp[i-1];
     }
-    cells = NEW_ARRAY(matvar_t*,N);
+
+    TRY {
+        cells = NEW_ARRAY(matvar_t*,N);
+    } CATCH(cells==NULL) {
+        END(Mat_Critical("Memory allocation failure"),NULL);
+    }
+
     for ( i = 0; i < N; i+=edge[0] ) {
         for ( j = 0; j < edge[0]; j++ ) {
             cells[i+j] = *((matvar_t **)matvar->data + I);
@@ -144,7 +150,11 @@ Mat_VarGetCellsLinear(matvar_t *matvar,int start,int stride,int edge)
     matvar_t **cells = NULL;
 
     if ( matvar != NULL ) {
-        cells = NEW_ARRAY(matvar_t*,edge);
+        TRY {
+            cells = NEW_ARRAY(matvar_t*,edge);
+        } CATCH(cells==NULL) {
+            END(Mat_Critical("Memory allocation failure"),NULL);
+        }
         I = start;
         for ( i = 0; i < edge; i++ ) {
             cells[i] = *((matvar_t **)matvar->data + I);

--- a/src/matvar_cell.c
+++ b/src/matvar_cell.c
@@ -100,7 +100,7 @@ Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,int *edge)
         N *= edge[i];
         I += start[i]*dimp[i-1];
     }
-    cells = (matvar_t**)malloc(N*sizeof(matvar_t *));
+    cells = NEW_ARRAY(matvar_t*,N);
     for ( i = 0; i < N; i+=edge[0] ) {
         for ( j = 0; j < edge[0]; j++ ) {
             cells[i+j] = *((matvar_t **)matvar->data + I);
@@ -144,7 +144,7 @@ Mat_VarGetCellsLinear(matvar_t *matvar,int start,int stride,int edge)
     matvar_t **cells = NULL;
 
     if ( matvar != NULL ) {
-        cells = (matvar_t**)malloc(edge*sizeof(matvar_t *));
+        cells = NEW_ARRAY(matvar_t*,edge);
         I = start;
         for ( i = 0; i < edge; i++ ) {
             cells[i] = *((matvar_t **)matvar->data + I);

--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -122,9 +122,10 @@ Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
 
     nfields = matvar->internal->num_fields+1;
     matvar->internal->num_fields = nfields;
-    matvar->internal->fieldnames =
-    (char**)realloc(matvar->internal->fieldnames,
-            nfields*sizeof(*matvar->internal->fieldnames));
+    char** fieldnames = NEW_ARRAY(char*,nfields);
+    memcpy(fieldnames,matvar->internal->fieldnames,(nfields-1)*sizeof(char*));
+    DELETE_ARRAY(matvar->internal->fieldnames);
+    matvar->internal->fieldnames = fieldnames;
     matvar->internal->fieldnames[nfields-1] = strdup(fieldname);
 
     new_data = NEW_ARRAY(matvar_t*,nfields*nmemb);
@@ -138,7 +139,7 @@ Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
         new_data[cnt++] = NULL;
     }
 
-    free(matvar->data);
+    DELETE_ARRAY(matvar->data);
     matvar->data = new_data;
     matvar->nbytes = nfields*nmemb*sizeof(*new_data);
 
@@ -498,7 +499,7 @@ Mat_VarSetStructFieldByIndex(matvar_t *matvar,size_t field_index,size_t index,
         old_field = fields[index*nfields+field_index];
         fields[index*nfields+field_index] = field;
         if ( NULL != field->name ) {
-            free(field->name);
+            DELETE_ARRAY(field->name);
         }
         field->name = strdup(matvar->internal->fieldnames[field_index]);
     }
@@ -547,7 +548,7 @@ Mat_VarSetStructFieldByName(matvar_t *matvar,const char *field_name,
         old_field = fields[index*nfields+field_index];
         fields[index*nfields+field_index] = field;
         if ( NULL != field->name ) {
-            free(field->name);
+            DELETE_ARRAY(field->name);
         }
         field->name = strdup(matvar->internal->fieldnames[field_index]);
     }

--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -113,6 +113,7 @@ Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
 {
     int       i, f, nfields, nmemb, cnt = 0;
     matvar_t **new_data, **old_data;
+    char     **fieldnames;
 
     if ( matvar == NULL || fieldname == NULL )
         return -1;
@@ -122,7 +123,7 @@ Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
 
     nfields = matvar->internal->num_fields+1;
     matvar->internal->num_fields = nfields;
-    char** fieldnames = NEW_ARRAY(char*,nfields);
+    fieldnames = NEW_ARRAY(char*,nfields);
     memcpy(fieldnames,matvar->internal->fieldnames,(nfields-1)*sizeof(char*));
     DELETE_ARRAY(matvar->internal->fieldnames);
     matvar->internal->fieldnames = fieldnames;

--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -58,7 +58,7 @@ Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
     if ( NULL != name )
         matvar->name = strdup(name);
     matvar->rank = rank;
-    matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+    matvar->dims = NEW_ARRAY(size_t,matvar->rank);
     for ( i = 0; i < matvar->rank; i++ ) {
         matvar->dims[i] = dims[i];
         nmemb *= dims[i];
@@ -70,8 +70,7 @@ Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
 
     if ( nfields ) {
         matvar->internal->num_fields = nfields;
-        matvar->internal->fieldnames =
-            (char**)malloc(nfields*sizeof(*matvar->internal->fieldnames));
+        matvar->internal->fieldnames = NEW_ARRAY(char*,nfields);
         if ( NULL == matvar->internal->fieldnames ) {
             Mat_VarFree(matvar);
             matvar = NULL;
@@ -89,7 +88,7 @@ Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
         if ( NULL != matvar && nmemb > 0 && nfields > 0 ) {
             matvar_t **field_vars;
             matvar->nbytes = nmemb*nfields*matvar->data_size;
-            matvar->data = malloc(matvar->nbytes);
+            matvar->data = NEW_ARRAY(char,matvar->nbytes);
             field_vars = (matvar_t**)matvar->data;
             for ( i = 0; i < nfields*nmemb; i++ )
                 field_vars[i] = NULL;
@@ -128,7 +127,7 @@ Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
             nfields*sizeof(*matvar->internal->fieldnames));
     matvar->internal->fieldnames[nfields-1] = strdup(fieldname);
 
-    new_data = (matvar_t**)malloc(nfields*nmemb*sizeof(*new_data));
+    new_data = NEW_ARRAY(matvar_t*,nfields*nmemb);
     if ( new_data == NULL )
         return -1;
 
@@ -366,7 +365,7 @@ Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,int *edge,
     }
     I *= nfields;
     struct_slab->nbytes    = N*nfields*sizeof(matvar_t *);
-    struct_slab->data = malloc(struct_slab->nbytes);
+    struct_slab->data = NEW_ARRAY(char,struct_slab->nbytes);
     if ( struct_slab->data == NULL ) {
         Mat_VarFree(struct_slab);
         return NULL;
@@ -440,7 +439,7 @@ Mat_VarGetStructsLinear(matvar_t *matvar,int start,int stride,int edge,
         nfields = matvar->internal->num_fields;
 
         struct_slab->nbytes = edge*nfields*sizeof(matvar_t *);
-        struct_slab->data = malloc(struct_slab->nbytes);
+        struct_slab->data = NEW_ARRAY(char,struct_slab->nbytes);
         struct_slab->dims[0] = edge;
         struct_slab->dims[1] = 1;
         fields = (matvar_t**)struct_slab->data;

--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -56,7 +56,7 @@ Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
 
     matvar->compression = MAT_COMPRESSION_NONE;
     if ( NULL != name )
-        matvar->name = strdup(name);
+        matvar->name = STRDUP(name);
     matvar->rank = rank;
     matvar->dims = NEW_ARRAY(size_t,matvar->rank);
     for ( i = 0; i < matvar->rank; i++ ) {
@@ -81,7 +81,7 @@ Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
                     matvar = NULL;
                     break;
                 } else {
-                    matvar->internal->fieldnames[i] = strdup(fields[i]);
+                    matvar->internal->fieldnames[i] = STRDUP(fields[i]);
                 }
             }
         }
@@ -126,7 +126,7 @@ Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
     memcpy(fieldnames,matvar->internal->fieldnames,(nfields-1)*sizeof(char*));
     DELETE_ARRAY(matvar->internal->fieldnames);
     matvar->internal->fieldnames = fieldnames;
-    matvar->internal->fieldnames[nfields-1] = strdup(fieldname);
+    matvar->internal->fieldnames[nfields-1] = STRDUP(fieldname);
 
     new_data = NEW_ARRAY(matvar_t*,nfields*nmemb);
     if ( new_data == NULL )
@@ -501,7 +501,7 @@ Mat_VarSetStructFieldByIndex(matvar_t *matvar,size_t field_index,size_t index,
         if ( NULL != field->name ) {
             DELETE_ARRAY(field->name);
         }
-        field->name = strdup(matvar->internal->fieldnames[field_index]);
+        field->name = STRDUP(matvar->internal->fieldnames[field_index]);
     }
 
     return old_field;
@@ -550,7 +550,7 @@ Mat_VarSetStructFieldByName(matvar_t *matvar,const char *field_name,
         if ( NULL != field->name ) {
             DELETE_ARRAY(field->name);
         }
-        field->name = strdup(matvar->internal->fieldnames[field_index]);
+        field->name = STRDUP(matvar->internal->fieldnames[field_index]);
     }
 
     return old_field;

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -1387,7 +1387,7 @@ rpl_vasprintf(char **ret, const char *format, va_list ap)
     len = vsnprintf(NULL, 0, format, aq);
 #endif
     VA_END_COPY(aq);
-    if (len < 0 || (*ret = (char*)malloc(size = len + 1)) == NULL)
+    if (len < 0 || (*ret = NEW_ARRAY(char,size = len + 1)) == NULL)
         return -1;
 #if !HAVE_VSNPRINTF
     return rpl_vsnprintf(*ret, size, format, ap);

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -390,6 +390,7 @@ static void *mymemcpy(void *, void *, size_t);
 #define ISINF(x) (x != 0.0 && x + x == x)
 #endif  /* !defined(ISINF) */
 
+
 #ifdef OUTCHAR
 #undef OUTCHAR
 #endif  /* defined(OUTCHAR) */
@@ -399,6 +400,12 @@ do {                                                                         \
         str[len] = ch;                                               \
     (len)++;                                                             \
 } while (/* CONSTCOND */ 0)
+
+#ifdef __cplusplus
+#define NEW_ARRAY(type,size) new type[size]
+#else
+#define NEW_ARRAY(type,size) (type*) malloc(size*sizeof(type))
+#endif
 
 static void fmtstr(char *, size_t *, size_t, const char *, int, int, int);
 static void fmtint(char *, size_t *, size_t, INTMAX_T, int, int, int, int);


### PR DESCRIPTION
This is another "just for discussion" pull request, even though it is already somewhat complete...
In OpenMEEG, we had complains of "strange" error messages and crashes when allocating big matrices. The problem is that OpenMEEG being a C++ program, we rely on exceptions to capture errors and fail gracefully. But matio uses plain malloc and justs exits (sometimes) when a memory allocation failure arises. In this branch, I replaced all memory allocations by macros that expand (or are equivalent to) the C code when compiled with C and to C++ allocation routines when compiling with C++. This is tested to work fine in both C and C++ compilations.... So now, if compiling in C++ mode, allocation failure now result in exceptions emitted. 

The drawback is that in C++ mode, no cleanup is made (because the if (var==NULL) blocks are not executed. To deal with that, I need to uglify  the code with macros simulating TRY {} CATCH() {}, which will become try {} catch(...) { CLEANUP } blocks in C++ mode and traditional if (var==NULL) {CLEANUP} blocks in C mode. 

One nice side effect of this work is that it is easy to identify all allocation points by grepping NEW. And if the TRY {}CATCH {} work is done, then all memory allocation failures will be caught, whereas this seems not to be the case currently.

Among other C++ improvements I might be interested to create are 
- to use the C++ IO system (this is because in OpenMEEG we want to read  files that are already open). But this requires an extension of the matio interface.
- wrap the various mat{4,5,7.3,,} routines in some C++ classes for easier use in C++ code. Of course, this has to be done without breaking the C interface
- extend the build system to build both a matio and a matio++ libraries.

Of course the first and second points need to be done without breaking the C interface. I have ideas, but I'm not totally sure if this can be done without uglifying the code too much. The last point is fairly easy (at least with the cmake build system I use, which will be the subject of another "just for discussion" pull request I will make once all the test reorganisation stuff will be integrated. With autoconf, this is doable but may need two separate builds (as it works currently, but we need to detect the C++ compiler and change the final library name).

