### PR TITLE
Add 'autoconf' to 'Quick Build Guide'

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ Table of Contents
           * Nils Jannasch (https://github.com/NJannasch)
           * OpenMEEG ((http://openmeeg.github.io/)
           * Scilab (http://www.scilab.org/)
-          * Sébastien Villemot (https://github.com/sebastien-villemot)
+          * SÃ©bastien Villemot (https://github.com/sebastien-villemot)
           * SGI in support of Interactive Supercomputing, Inc.
           * Steven Leibman <sleibman@alum.mit.edu>
 
@@ -90,12 +90,14 @@ Table of Contents
 
     2.2 Building matio
         2.2.1 Quick Build Guide
-            The primary method for building the software is using 'configure'
-            followed by 'make'. After building, the testsuite can be executed to
+            The primary method for building the software is running 'autoconf' to
+            produce the configure skript then using 'configure' followed by 'make'.
+            After building, the testsuite can be executed to
             test the software using 'make check'. The software can be installed
             using 'make install'. For example,
                 $ tar zxf matio-X.Y.Z.tar.gz
                 $ cd matio-X.Y.Z
+                $ autoconf
                 $ ./configure
                 $ make
                 $ make check


### PR DESCRIPTION
For someone strictly following the 'Quick Build Guide' running './configure' will produce 'bash: ./configure: No such file or directory'. To spare others the same problem 'autoconf' was added to the guide which will produce the missing configure script with the given 'configure.ac'.

I did not change anything on line 42 but GitHub automatically changed the encoding of the file from ISO-8859-1 to UTF-8, which I guess is leading GitHub to mark the line as changed.