### PR TITLE
Convert to pragma once.

### DIFF
--- a/getopt/getopt.h
+++ b/getopt/getopt.h
@@ -37,8 +37,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _GETOPT_H_
-#define _GETOPT_H_
+#pragma once
 
 #if !defined(_WIN32) && !defined(_WIN64)
 #   include <sys/cdefs.h>
@@ -81,5 +80,3 @@ extern int optind, opterr, optopt;
 #define _OPTRESET_DECLARED
 extern int optreset;            /* getopt(3) external variable */
 #endif
-
-#endif /* !_GETOPT_H_ */

--- a/src/mat4.h
+++ b/src/mat4.h
@@ -25,8 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MAT4_H
-#define MAT4_H
+#pragma once
 
 #ifdef __cplusplus
 #   define EXTERN extern "C"
@@ -43,5 +42,3 @@ EXTERN int       ReadData4(mat_t *mat,matvar_t *matvar,void *data,
 EXTERN int       Mat_VarReadDataLinear4(mat_t *mat,matvar_t *matvar,void *data,int start,
                      int stride,int edge);
 EXTERN matvar_t *Mat_VarReadNextInfo4(mat_t *mat);
-
-#endif

--- a/src/mat5.h
+++ b/src/mat5.h
@@ -25,8 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MAT5_H
-#define MAT5_H
+#pragma once
 
 #ifdef __cplusplus
 #   define EXTERN extern "C"
@@ -49,5 +48,3 @@ EXTERN int       WriteData(mat_t *mat,void *data,int N,enum matio_types data_typ
 EXTERN int       WriteDataSlab2(mat_t *mat,void *data,enum matio_types data_type,
                      size_t *dims,int *start,int *stride,int *edge);
 EXTERN void      WriteInfo5(mat_t *mat, matvar_t *matvar);
-
-#endif

--- a/src/mat73.h
+++ b/src/mat73.h
@@ -25,8 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MAT73_H
-#define MAT73_H
+#pragma once
 
 #include <hdf5.h>
 
@@ -47,5 +46,3 @@ EXTERN matvar_t *Mat_VarReadNextInfo73(mat_t *mat);
 EXTERN int       Mat_VarWrite73(mat_t *mat,matvar_t *matvar,int compress);
 EXTERN int       Mat_VarWriteAppend73(mat_t *mat,matvar_t *matvar,int compress,
                      int dim);
-
-#endif

--- a/src/matio.h
+++ b/src/matio.h
@@ -30,8 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef MATIO_H
-#define MATIO_H
+#pragma once
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -320,5 +319,3 @@ EXTERN int     Mat_CalcSingleSubscript(int rank,int *dims,int *subs);
 EXTERN int     Mat_CalcSingleSubscript2(int rank,size_t *dims,size_t *subs,size_t *index);
 EXTERN int    *Mat_CalcSubscripts(int rank,int *dims,int index);
 EXTERN size_t *Mat_CalcSubscripts2(int rank,size_t *dims,size_t index);
-
-#endif

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -25,8 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MATIO_PRIVATE_H
-#define MATIO_PRIVATE_H
+#pragma once
 
 #include "matioConfig.h"
 #include "matio.h"
@@ -225,5 +224,3 @@ EXTERN size_t InflateFieldNames(mat_t *mat,matvar_t *matvar,void *buf,int nfield
 
 /* mat.c */
 EXTERN mat_complex_split_t *ComplexMalloc(size_t nbytes);
-
-#endif

--- a/src/matio_pubconf.h.in
+++ b/src/matio_pubconf.h.in
@@ -25,8 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MATIO_PUBCONF_H
-#define MATIO_PUBCONF_H 1
+#pragma once
 
 /* Matio major version number */
 #undef MATIO_MAJOR_VERSION
@@ -154,5 +153,3 @@
 #define MATIO_NORETURN
 #define MATIO_NORETURNATTR
 #endif
-
-#endif /* MATIO_PUBCONF_H */

--- a/visual_studio/matio_pubconf.h
+++ b/visual_studio/matio_pubconf.h
@@ -25,8 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MATIO_PUBCONF_H
-#define MATIO_PUBCONF_H 1
+#pragma once
 
 /* Matio major version number */
 #define MATIO_MAJOR_VERSION 1
@@ -166,5 +165,3 @@
 #else
 #define MATIO_NORETURN
 #endif
-
-#endif /* MATIO_PUBCONF_H */


### PR DESCRIPTION
Simple change to convert .h files to #pragma once.
All modern C compilers I know support this. 
But there is the Portland compiler that matio seems to support (I'm not sure how many builds are made with this compiler).
https://en.wikipedia.org/wiki/Pragma_once
Anyway, I'm putting this here for reference.
All test pass.