### PR TITLE
Correct an overflow bug in Read5.

### DIFF
--- a/src/mat5.c
+++ b/src/mat5.c
@@ -3139,7 +3139,8 @@ Mat_VarReadNumeric5(mat_t *mat,matvar_t *matvar,void *data,size_t N)
 void
 Read5(mat_t *mat, matvar_t *matvar)
 {
-    int nBytes = 0, len = 1, i, byteswap, data_in_tag = 0;
+    int nBytes = 0, i, byteswap, data_in_tag = 0;
+    size_t len = 1;
     enum matio_types packed_type = MAT_T_UNKNOWN;
     long fpos;
     mat_uint32_t tag[2];


### PR DESCRIPTION
This simple patch corrects issue #91.