### PR TITLE
Write backwards compatible Mat7.3 files

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -408,8 +408,15 @@ Mat_Open(const char *matname,int mode)
 
         if ( (mode & 0x01) == MAT_ACC_RDONLY )
             *(hid_t*)mat->fp=H5Fopen(mat->filename,H5F_ACC_RDONLY,H5P_DEFAULT);
-        else if ( (mode & 0x01) == MAT_ACC_RDWR )
-            *(hid_t*)mat->fp=H5Fopen(mat->filename,H5F_ACC_RDWR,H5P_DEFAULT);
+        else if ( (mode & 0x01) == MAT_ACC_RDWR ) {
+            hid_t plist_ap;
+            plist_ap = H5Pcreate(H5P_FILE_ACCESS);
+#if H5_VERSION_GE(1,10,2)
+            H5Pset_libver_bounds(plist_ap,H5F_LIBVER_EARLIEST,H5F_LIBVER_V18);
+#endif
+            *(hid_t*)mat->fp=H5Fopen(mat->filename,H5F_ACC_RDWR,plist_ap);
+            H5Pclose(plist_ap);
+        }
 
         if ( -1 < *(hid_t*)mat->fp ) {
             H5G_info_t group_info;

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -2200,11 +2200,15 @@ Mat_Create73(const char *matname,const char *hdr_str)
     mat_t *mat = NULL;
     size_t err;
     time_t t;
-    hid_t plist_id,fid;
+    hid_t plist_id,fid,plist_ap;
 
     plist_id = H5Pcreate(H5P_FILE_CREATE);
     H5Pset_userblock(plist_id,512);
-    fid = H5Fcreate(matname,H5F_ACC_TRUNC,plist_id,H5P_DEFAULT);
+    plist_ap = H5Pcreate(H5P_FILE_ACCESS);
+#if H5_VERSION_GE(1,10,2)
+    H5Pset_libver_bounds(plist_ap,H5F_LIBVER_EARLIEST,H5F_LIBVER_V18);
+#endif
+    fid = H5Fcreate(matname,H5F_ACC_TRUNC,plist_id,plist_ap);
     H5Fclose(fid);
     H5Pclose(plist_id);
 
@@ -2263,7 +2267,8 @@ Mat_Create73(const char *matname,const char *hdr_str)
 
     fclose(fp);
 
-    fid = H5Fopen(matname,H5F_ACC_RDWR,H5P_DEFAULT);
+    fid = H5Fopen(matname,H5F_ACC_RDWR,plist_ap);
+    H5Pclose(plist_ap);
 
     mat->fp = malloc(sizeof(hid_t));
     *(hid_t*)mat->fp = fid;

--- a/src/read_data.c
+++ b/src/read_data.c
@@ -29,6 +29,7 @@
  */
 
 /* FIXME: Implement Unicode support */
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -1437,10 +1438,10 @@ ReadCharData(mat_t *mat,char *data,enum matio_types data_type,int len)
                 cnt[j] = 0; \
                 if ( (I % dimp[j]) != 0 ) { \
                     (void)fseek((FILE*)mat->fp,data_size*(dimp[j]-(I % dimp[j]) + dimp[j-1]*start[j]),SEEK_CUR); \
-                    I += dimp[j]-(I % dimp[j]) + dimp[j-1]*start[j]; \
+                    I += dimp[j]-(I % dimp[j]) + (ptrdiff_t)dimp[j-1]*start[j]; \
                 } else if ( start[j] ) { \
                     (void)fseek((FILE*)mat->fp,data_size*(dimp[j-1]*start[j]),SEEK_CUR); \
-                    I += dimp[j-1]*start[j]; \
+                    I += (ptrdiff_t)dimp[j-1]*start[j]; \
                 } \
             } else { \
                 I += inc[j]; \
@@ -1464,7 +1465,7 @@ ReadCharData(mat_t *mat,char *data,enum matio_types data_type,int len)
                 dimp[i] *= dims[j+1]; \
             } \
             N *= edge[i]; \
-            I += dimp[i-1]*start[i]; \
+            I += (ptrdiff_t)dimp[i-1]*start[i]; \
         } \
         (void)fseek((FILE*)mat->fp,I*data_size,SEEK_CUR); \
         if ( stride[0] == 1 ) { \
@@ -1490,9 +1491,9 @@ ReadCharData(mat_t *mat,char *data,enum matio_types data_type,int len)
                     (void)fseek((FILE*)mat->fp,data_size*(stride[0]-1),SEEK_CUR); \
                     I += stride[0]; \
                 } \
-                I += dims[0]-edge[0]*stride[0]-start[0]; \
+                I += dims[0]-(ptrdiff_t)edge[0]*stride[0]-start[0]; \
                 (void)fseek((FILE*)mat->fp,data_size* \
-                    (dims[0]-edge[0]*stride[0]-start[0]),SEEK_CUR); \
+                    (dims[0]-(ptrdiff_t)edge[0]*stride[0]-start[0]),SEEK_CUR); \
                 READ_DATA_SLABN_RANK_LOOP; \
             } \
         } \
@@ -1613,10 +1614,10 @@ ReadDataSlabN(mat_t *mat,void *data,enum matio_classes class_type,
                 cnt[j] = 0; \
                 if ( (I % dimp[j]) != 0 ) { \
                     InflateSkipData(mat,&z_copy,data_type, dimp[j]-(I % dimp[j]) + dimp[j-1]*start[j]); \
-                    I += dimp[j]-(I % dimp[j]) + dimp[j-1]*start[j]; \
+                    I += dimp[j]-(I % dimp[j]) + (ptrdiff_t)dimp[j-1]*start[j]; \
                 } else if ( start[j] ) { \
                     InflateSkipData(mat,&z_copy,data_type, dimp[j-1]*start[j]); \
-                    I += dimp[j-1]*start[j]; \
+                    I += (ptrdiff_t)dimp[j-1]*start[j]; \
                 } \
             } else { \
                 if ( inc[j] ) { \
@@ -1642,7 +1643,7 @@ ReadDataSlabN(mat_t *mat,void *data,enum matio_classes class_type,
                 dimp[i] *= dims[j+1]; \
             } \
             N *= edge[i]; \
-            I += dimp[i-1]*start[i]; \
+            I += (ptrdiff_t)dimp[i-1]*start[i]; \
         } \
         /* Skip all data to the starting indices */ \
         InflateSkipData(mat,&z_copy,data_type,I); \
@@ -1669,7 +1670,7 @@ ReadDataSlabN(mat_t *mat,void *data,enum matio_classes class_type,
                     I += stride[0]; \
                 } \
                 ReadDataFunc(mat,&z_copy,ptr+i+j,data_type,1); \
-                I += dims[0]-(edge[0]-1)*stride[0]-start[0]; \
+                I += dims[0]-(ptrdiff_t)(edge[0]-1)*stride[0]-start[0]; \
                 InflateSkipData(mat,&z_copy,data_type,dims[0]-(edge[0]-1)*stride[0]-start[0]-1); \
                 READ_COMPRESSED_DATA_SLABN_RANK_LOOP; \
             } \
@@ -1910,14 +1911,14 @@ ReadDataSlab1(mat_t *mat,void *data,enum matio_classes class_type,
                 Mat_Critical("Couldn't determine file position"); \
                 return -1; \
             } \
-            (void)fseek((FILE*)mat->fp,start[1]*dims[0]*data_size,SEEK_CUR); \
+            (void)fseek((FILE*)mat->fp,(long)start[1]*dims[0]*data_size,SEEK_CUR); \
             for ( i = 0; i < edge[1]; i++ ) { \
                 pos = ftell((FILE*)mat->fp); \
                 if ( pos == -1L ) { \
                     Mat_Critical("Couldn't determine file position"); \
                     return -1; \
                 } \
-                (void)fseek((FILE*)mat->fp,start[0]*data_size,SEEK_CUR); \
+                (void)fseek((FILE*)mat->fp,(long)start[0]*data_size,SEEK_CUR); \
                 for ( j = 0; j < edge[0]; j++ ) { \
                     ReadDataFunc(mat,ptr++,data_type,1); \
                     (void)fseek((FILE*)mat->fp,row_stride,SEEK_CUR); \


### PR DESCRIPTION
When Matio uses HDF5 1.10.x, it may create files using features only
supported with newer versions.
Limiting the version range for compatibility was added in HDF5 1.10.2.
For details, see
https://www.hdfgroup.org/2018/04/why-should-i-care-about-the-hdf5-1-10-2-release/