### PR TITLE
Avoid using mktemp (considered harmful)

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -1012,6 +1012,13 @@ mat_copy(const char* src, const char* dst)
     return 0;
 }
 
+// Using mktemp causes GCC to complain, but mkstemp doesn't exist on Windows
+#ifdef _MSC_VER
+#define MKTEMP mktemp
+#else
+#define MKTEMP mkstemp
+#endif
+
 /** @brief Deletes a variable from a file
  *
  * @ingroup MAT
@@ -1029,7 +1036,7 @@ Mat_VarDelete(mat_t *mat, const char *name)
     if ( NULL == mat || NULL == name )
         return err;
 
-    if ( (tmp_name = mktemp(temp)) != NULL ) {
+    if ( (tmp_name = MKTEMP(temp)) != NULL ) {
         enum mat_ft mat_file_ver;
         mat_t *tmp;
 


### PR DESCRIPTION
At link time, GCC emits the following: `warning: the use of 'mktemp' is dangerous, better use 'mkstemp'`. This patch uses `mkstemp` intead, as recommended.