### PR TITLE
Fix so prototype matches implementation

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -1033,11 +1033,11 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
             sparse_data->nir   = sparse_data_in->nir;
             sparse_data->njc   = sparse_data_in->njc;
             sparse_data->ndata = sparse_data_in->ndata;
-            sparse_data->ir = (mat_int32_t*)malloc(sparse_data->nir*sizeof(*sparse_data->ir));
+            sparse_data->ir = (mat_uint32_t*)malloc(sparse_data->nir*sizeof(*sparse_data->ir));
             if ( NULL != sparse_data->ir )
                 memcpy(sparse_data->ir,sparse_data_in->ir,
                        sparse_data->nir*sizeof(*sparse_data->ir));
-            sparse_data->jc = (mat_int32_t*)malloc(sparse_data->njc*sizeof(*sparse_data->jc));
+            sparse_data->jc = (mat_uint32_t*)malloc(sparse_data->njc*sizeof(*sparse_data->jc));
             if ( NULL != sparse_data->jc )
                 memcpy(sparse_data->jc,sparse_data_in->jc,
                        sparse_data->njc*sizeof(*sparse_data->jc));
@@ -1357,11 +1357,11 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
                     mat_sparse_t *in_sparse  = (mat_sparse_t*)in->internal->data;
                     out_sparse->nzmax = in_sparse->nzmax;
                     out_sparse->nir = in_sparse->nir;
-                    out_sparse->ir = (mat_int32_t*)malloc(in_sparse->nir*sizeof(*out_sparse->ir));
+                    out_sparse->ir = (mat_uint32_t*)malloc(in_sparse->nir*sizeof(*out_sparse->ir));
                     if ( out_sparse->ir != NULL )
                         memcpy(out_sparse->ir, in_sparse->ir, in_sparse->nir*sizeof(*out_sparse->ir));
                     out_sparse->njc = in_sparse->njc;
-                    out_sparse->jc = (mat_int32_t*)malloc(in_sparse->njc*sizeof(*out_sparse->jc));
+                    out_sparse->jc = (mat_uint32_t*)malloc(in_sparse->njc*sizeof(*out_sparse->jc));
                     if ( out_sparse->jc != NULL )
                         memcpy(out_sparse->jc, in_sparse->jc, in_sparse->njc*sizeof(*out_sparse->jc));
                     out_sparse->ndata = in_sparse->ndata;
@@ -1439,11 +1439,11 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
             mat_sparse_t *in_sparse  = (mat_sparse_t*)in->data;
             out_sparse->nzmax = in_sparse->nzmax;
             out_sparse->nir = in_sparse->nir;
-            out_sparse->ir = (mat_int32_t*)malloc(in_sparse->nir*sizeof(*out_sparse->ir));
+            out_sparse->ir = (mat_uint32_t*)malloc(in_sparse->nir*sizeof(*out_sparse->ir));
             if ( out_sparse->ir != NULL )
                 memcpy(out_sparse->ir, in_sparse->ir, in_sparse->nir*sizeof(*out_sparse->ir));
             out_sparse->njc = in_sparse->njc;
-            out_sparse->jc = (mat_int32_t*)malloc(in_sparse->njc*sizeof(*out_sparse->jc));
+            out_sparse->jc = (mat_uint32_t*)malloc(in_sparse->njc*sizeof(*out_sparse->jc));
             if ( out_sparse->jc != NULL )
                 memcpy(out_sparse->jc, in_sparse->jc, in_sparse->njc*sizeof(*out_sparse->jc));
             out_sparse->ndata = in_sparse->ndata;

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -62,7 +62,7 @@ static int GetStructFieldBufSize(matvar_t *matvar, size_t *size);
 static int GetCellArrayFieldBufSize(matvar_t *matvar, size_t *size);
 static void SetFieldNames(matvar_t *matvar, char *buf, size_t nfields,
                   mat_uint32_t fieldname_length);
-static size_t ReadSparse(mat_t *mat, matvar_t *matvar, int *n, mat_uint32_t **v);
+static size_t ReadSparse(mat_t *mat, matvar_t *matvar, mat_uint32_t *n, mat_uint32_t **v);
 #if defined(HAVE_ZLIB)
 static int GetMatrixMaxBufSize(matvar_t *matvar, size_t *size);
 #endif

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -4641,8 +4641,10 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
 
         uncomp_buf[0] = MAT_T_MATRIX;
         err = GetMatrixMaxBufSize(matvar, &matrix_max_buf_size);
-        if (err || matrix_max_buf_size > UINT32_MAX)
+        if ( err || matrix_max_buf_size > UINT32_MAX ) {
+            free(z);
             return -1;
+        }
         uncomp_buf[1] = matrix_max_buf_size;
         z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
         z->avail_in = 8;

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -404,7 +404,7 @@ SetFieldNames(matvar_t *matvar, char *buf, size_t nfields, mat_uint32_t fieldnam
 }
 
 static size_t
-ReadSparse(mat_t *mat, matvar_t *matvar, int *n, mat_uint32_t **v)
+ReadSparse(mat_t *mat, matvar_t *matvar, mat_uint32_t *n, mat_uint32_t **v)
 {
     int data_in_tag = 0;
     enum matio_types packed_type;

--- a/src/matio.h
+++ b/src/matio.h
@@ -205,17 +205,17 @@ typedef struct matvar_t {
  * @ingroup MAT
  */
 typedef struct mat_sparse_t {
-    int nzmax;               /**< Maximum number of non-zero elements */
-    mat_int32_t *ir;         /**< Array of size nzmax where ir[k] is the row of
+    mat_uint32_t  nzmax;     /**< Maximum number of non-zero elements */
+    mat_uint32_t *ir;        /**< Array of size nzmax where ir[k] is the row of
                                *  data[k].  0 <= k <= nzmax
                                */
-    int nir;                 /**< number of elements in ir */
-    mat_int32_t *jc;         /**< Array size N+1 (N is number of columns) with
+    mat_uint32_t  nir;       /**< number of elements in ir */
+    mat_uint32_t *jc;        /**< Array size N+1 (N is number of columns) with
                                *  jc[k] being the index into ir/data of the
                                *  first non-zero element for row k.
                                */
-    int   njc;               /**< Number of elements in jc */
-    int   ndata;             /**< Number of complex/real data values */
+    mat_uint32_t  njc;       /**< Number of elements in jc */
+    mat_uint32_t  ndata;     /**< Number of complex/real data values */
     void *data;              /**< Array of data elements */
 } mat_sparse_t;
 

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -140,31 +140,31 @@ EXTERN mat_int16_t   Mat_int16Swap(mat_int16_t  *a);
 EXTERN mat_uint16_t  Mat_uint16Swap(mat_uint16_t *a);
 
 /* read_data.c */
-EXTERN int ReadDoubleData(mat_t *mat,double *data,enum matio_types data_type,
+EXTERN size_t ReadDoubleData(mat_t *mat,double *data,enum matio_types data_type,
                size_t len);
-EXTERN int ReadSingleData(mat_t *mat,float  *data,enum matio_types data_type,
+EXTERN size_t ReadSingleData(mat_t *mat,float  *data,enum matio_types data_type,
                size_t len);
 #ifdef HAVE_MAT_INT64_T
-EXTERN int ReadInt64Data (mat_t *mat,mat_int64_t *data,
+EXTERN size_t ReadInt64Data (mat_t *mat,mat_int64_t *data,
                enum matio_types data_type,size_t len);
 #endif /* HAVE_MAT_INT64_T */
 #ifdef HAVE_MAT_UINT64_T
-EXTERN int ReadUInt64Data(mat_t *mat,mat_uint64_t *data,
+EXTERN size_t ReadUInt64Data(mat_t *mat,mat_uint64_t *data,
                enum matio_types data_type,size_t len);
 #endif /* HAVE_MAT_UINT64_T */
-EXTERN int ReadInt32Data (mat_t *mat,mat_int32_t *data,
+EXTERN size_t ReadInt32Data (mat_t *mat,mat_int32_t *data,
                enum matio_types data_type,size_t len);
-EXTERN int ReadUInt32Data(mat_t *mat,mat_uint32_t *data,
+EXTERN size_t ReadUInt32Data(mat_t *mat,mat_uint32_t *data,
                enum matio_types data_type,size_t len);
-EXTERN int ReadInt16Data (mat_t *mat,mat_int16_t *data,
+EXTERN size_t ReadInt16Data (mat_t *mat,mat_int16_t *data,
                enum matio_types data_type,size_t len);
-EXTERN int ReadUInt16Data(mat_t *mat,mat_uint16_t *data,
+EXTERN size_t ReadUInt16Data(mat_t *mat,mat_uint16_t *data,
                enum matio_types data_type,size_t len);
-EXTERN int ReadInt8Data  (mat_t *mat,mat_int8_t  *data,
+EXTERN size_t ReadInt8Data  (mat_t *mat,mat_int8_t  *data,
                enum matio_types data_type,size_t len);
-EXTERN int ReadUInt8Data (mat_t *mat,mat_uint8_t  *data,
+EXTERN size_t ReadUInt8Data (mat_t *mat,mat_uint8_t  *data,
                enum matio_types data_type,size_t len);
-EXTERN int ReadCharData  (mat_t *mat,char  *data,enum matio_types data_type,
+EXTERN size_t ReadCharData  (mat_t *mat,char  *data,enum matio_types data_type,
                int len);
 EXTERN int ReadDataSlab1(mat_t *mat,void *data,enum matio_classes class_type,
                enum matio_types data_type,int start,int stride,int edge);

--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -93,8 +93,10 @@ Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
             size_t nelems_x_nfields;
             int err = SafeMul(&nelems_x_nfields, nelems, nfields);
             err |= SafeMul(&matvar->nbytes, nelems_x_nfields, matvar->data_size);
-            if ( err )
+            if ( err ) {
+                Mat_VarFree(matvar);
                 return NULL;
+            }
             matvar->data = calloc(nelems_x_nfields, matvar->data_size);
         }
     }

--- a/src/read_data_impl.h
+++ b/src/read_data_impl.h
@@ -42,10 +42,10 @@
 static size_t
 READ_TYPE_DOUBLE_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_DOUBLE
-    readcount += fread(data, sizeof(double), len, (FILE*)mat->fp);
-    if ( mat->byteswap ) {
+    readcount = fread(data, sizeof(double), len, (FILE*)mat->fp);
+    if ( readcount == len && mat->byteswap ) {
         size_t i;
         for ( i = 0; i < len; i++ ) {
             (void)Mat_doubleSwap(data + i);
@@ -63,10 +63,10 @@ READ_TYPE_DOUBLE_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_SINGLE_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_SINGLE
-    readcount += fread(data, sizeof(float), len, (FILE*)mat->fp);
-    if ( mat->byteswap ) {
+    readcount = fread(data, sizeof(float), len, (FILE*)mat->fp);
+    if ( readcount == len && mat->byteswap ) {
         size_t i;
         for ( i = 0; i < len; i++ ) {
             (void)Mat_floatSwap(data + i);
@@ -84,10 +84,10 @@ READ_TYPE_SINGLE_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_INT32_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_INT32
-    readcount += fread(data, sizeof(mat_int32_t), len, (FILE*)mat->fp);
-    if ( mat->byteswap ) {
+    readcount = fread(data, sizeof(mat_int32_t), len, (FILE*)mat->fp);
+    if ( readcount == len && mat->byteswap ) {
         size_t i;
         for ( i = 0; i < len; i++ ) {
             (void)Mat_int32Swap(data + i);
@@ -105,10 +105,10 @@ READ_TYPE_INT32_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_UINT32_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_UINT32
-    readcount += fread(data, sizeof(mat_uint32_t), len, (FILE*)mat->fp);
-    if ( mat->byteswap ) {
+    readcount = fread(data, sizeof(mat_uint32_t), len, (FILE*)mat->fp);
+    if ( readcount == len && mat->byteswap ) {
         size_t i;
         for ( i = 0; i < len; i++ ) {
             (void)Mat_uint32Swap(data + i);
@@ -126,10 +126,10 @@ READ_TYPE_UINT32_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_INT16_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_INT16
-    readcount += fread(data, sizeof(mat_int16_t), len, (FILE*)mat->fp);
-    if ( mat->byteswap ) {
+    readcount = fread(data, sizeof(mat_int16_t), len, (FILE*)mat->fp);
+    if ( readcount == len && mat->byteswap ) {
         size_t i;
         for ( i = 0; i < len; i++ ) {
             (void)Mat_int16Swap(data + i);
@@ -147,10 +147,10 @@ READ_TYPE_INT16_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_UINT16_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_UINT16
-    readcount += fread(data, sizeof(mat_uint16_t), len, (FILE*)mat->fp);
-    if ( mat->byteswap ) {
+    readcount = fread(data, sizeof(mat_uint16_t), len, (FILE*)mat->fp);
+    if ( readcount == len && mat->byteswap ) {
         size_t i;
         for ( i = 0; i < len; i++ ) {
             (void)Mat_uint16Swap(data + i);
@@ -168,9 +168,9 @@ READ_TYPE_UINT16_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_INT8_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_INT8
-    readcount += fread(data, sizeof(mat_int8_t), len, (FILE*)mat->fp);
+    readcount = fread(data, sizeof(mat_int8_t), len, (FILE*)mat->fp);
 #else
     size_t i;
     const size_t data_size = sizeof(mat_int8_t);
@@ -183,9 +183,9 @@ READ_TYPE_INT8_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_UINT8_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_UINT8
-    readcount += fread(data, sizeof(mat_uint8_t), len, (FILE*)mat->fp);
+    readcount = fread(data, sizeof(mat_uint8_t), len, (FILE*)mat->fp);
 #else
     size_t i;
     const size_t data_size = sizeof(mat_uint8_t);
@@ -199,10 +199,10 @@ READ_TYPE_UINT8_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_INT64_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_INT64
-    readcount += fread(data, sizeof(mat_int64_t), len, (FILE*)mat->fp);
-    if ( mat->byteswap ) {
+    readcount = fread(data, sizeof(mat_int64_t), len, (FILE*)mat->fp);
+    if ( readcount == len && mat->byteswap ) {
         size_t i;
         for ( i = 0; i < len; i++ ) {
             (void)Mat_int64Swap(data + i);
@@ -222,10 +222,10 @@ READ_TYPE_INT64_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 static size_t
 READ_TYPE_UINT64_DATA(mat_t *mat, READ_TYPE *data, size_t len)
 {
-    size_t readcount = 0;
+    size_t readcount;
 #if READ_TYPE_TYPE == READ_TYPE_UINT64
-    readcount += fread(data, sizeof(mat_uint64_t), len, (FILE*)mat->fp);
-    if ( mat->byteswap ) {
+    readcount = fread(data, sizeof(mat_uint64_t), len, (FILE*)mat->fp);
+    if ( readcount == len && mat->byteswap ) {
         size_t i;
         for ( i = 0; i < len; i++ ) {
             (void)Mat_uint64Swap(data + i);
@@ -254,7 +254,7 @@ READ_TYPE_UINT64_DATA(mat_t *mat, READ_TYPE *data, size_t len)
  * @param len Number of elements of type @c data_type to read from the file
  * @retval Number of elements read from the file
  */
-int
+size_t
 READ_TYPED_FUNC1(mat_t *mat, READ_TYPE *data, enum matio_types data_type, size_t len)
 {
     size_t readcount;


### PR DESCRIPTION
The argument type of one of the arguments in the declaration of `ReadSparse` was not changed when the corresponding argument type was changed at the implementation site.