### PR TITLE
fix mktemp linker warnings when using GNU linker

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -65,8 +65,8 @@
 #define MAT_MKTEMP_TPL "XXXXXX"
 #define MAT_MKTEMP_FILE "/temp.mat"
 
-static const size_t MAT_MKTEMP_BUF_SIZE =
-  sizeof(MAT_MKTEMP_DIR)+sizeof(MAT_MKTEMP_TPL)+sizeof(MAT_MKTEMP_FILE)-2;
+#define MAT_MKTEMP_BUF_SIZE \
+  (sizeof(MAT_MKTEMP_DIR)+sizeof(MAT_MKTEMP_TPL)+sizeof(MAT_MKTEMP_FILE)-2)
 
 static char *
 Mat_mktemp(char *path_buf, char *dir_buf)


### PR DESCRIPTION
Use mkdtemp() to create a temporary directory with a unique name,
then add a constant filename to the path after that. This allows
us to construct a unique path without any race conditions, and
without having to use mktemp().

Hopefully doing it this way avoids the issues you were having
with getting mkstemp() to work in #43.