### PR TITLE
Update mat5.c to support uncompressed MAT file generated by SWAN 

### DIFF
--- a/src/mat5.c
+++ b/src/mat5.c
@@ -5282,7 +5282,7 @@ Mat_VarReadNextInfo5( mat_t *mat )
             }
 
             /* Array flags */
-            if ( buf[0] == MAT_T_UINT32 ) {
+            if ( buf[0] == MAT_T_UINT32 || buf[0] == MAT_T_INT32 ) { /* Also allow INT32 for SWAN */
                array_flags = buf[2];
                matvar->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
                matvar->isComplex  = (array_flags & MAT_F_COMPLEX);


### PR DESCRIPTION
Slight modification to Mat_VarReadNextInfo5() to allow MAT_T_INT32 in addition to MAT_T_UINT32 to indicate processing of array_flags.

This formatting was encountered processing older .mat files created by older versions of the swan model (https://www.tudelft.nl/en/ceg/about-faculty/departments/hydraulic-engineering/sections/environmental-fluid-mechanics/research/swan/).

I have no idea if this violates the file format specification, but Matlab and libmat.lib both read such files without complaint.
