### PR TITLE
Don't use existing CMake target names.

### DIFF
--- a/cmake/src.cmake
+++ b/cmake/src.cmake
@@ -65,11 +65,11 @@ if(WIN32)
 endif()
 
 if(HDF5_FOUND)
-    target_link_libraries(${PROJECT_NAME} PUBLIC HDF5::HDF5)
+    target_link_libraries(${PROJECT_NAME} PUBLIC MATIO::HDF5)
 endif()
 
 if(ZLIB_FOUND)
-    target_link_libraries(${PROJECT_NAME} PUBLIC ZLIB::ZLIB)
+    target_link_libraries(${PROJECT_NAME} PUBLIC MATIO::ZLIB)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ${MATIO_PIC})

--- a/cmake/thirdParties.cmake
+++ b/cmake/thirdParties.cmake
@@ -31,28 +31,31 @@ endif()
 
 if(HDF5_FOUND)
     set(HAVE_HDF5 1)
-    add_library(HDF5::HDF5 INTERFACE IMPORTED)
+    add_library(MATIO::HDF5 INTERFACE IMPORTED)
     if(MATIO_USE_CONAN AND TARGET CONAN_PKG::hdf5)
         # target from Conan
-        target_link_libraries(HDF5::HDF5 INTERFACE CONAN_PKG::hdf5)
+        target_link_libraries(MATIO::HDF5 INTERFACE CONAN_PKG::hdf5)
     elseif(HDF5_USE_STATIC_LIBRARIES AND TARGET hdf5::hdf5-static)
         # static target from hdf5 1.10 or 1.12 config
-        target_link_libraries(HDF5::HDF5 INTERFACE hdf5::hdf5-static)
+        target_link_libraries(MATIO::HDF5 INTERFACE hdf5::hdf5-static)
     elseif(NOT HDF5_USE_STATIC_LIBRARIES AND TARGET hdf5::hdf5-shared)
         # shared target from hdf5 1.10 or 1.12 config
-        target_link_libraries(HDF5::HDF5 INTERFACE hdf5::hdf5-shared)
+        target_link_libraries(MATIO::HDF5 INTERFACE hdf5::hdf5-shared)
     elseif(TARGET hdf5)
         # target from hdf5 1.8 config
-        target_link_libraries(HDF5::HDF5 INTERFACE hdf5)
+        target_link_libraries(MATIO::HDF5 INTERFACE hdf5)
+    elseif(TARGET HDF5::HDF5)
+        # target defined in CMake FindHDF5 (since 3.19)
+        target_link_libraries(MATIO::HDF5 INTERFACE HDF5::HDF5)
     else()
         # results from CMake FindHDF5
-        set_target_properties(HDF5::HDF5 PROPERTIES
+        set_target_properties(MATIO::HDF5 PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}"
             INTERFACE_LINK_LIBRARIES "${HDF5_LIBRARIES}"
         )
     endif()
     if(NOT HDF5_USE_STATIC_LIBRARIES)
-        set_target_properties(HDF5::HDF5 PROPERTIES
+        set_target_properties(MATIO::HDF5 PROPERTIES
             INTERFACE_COMPILE_DEFINITIONS "H5_BUILT_AS_DYNAMIC_LIB"
         )
     endif()
@@ -64,8 +67,8 @@ endif()
 
 
 macro(matio_create_zlib target)
-    add_library(ZLIB::ZLIB INTERFACE IMPORTED)
-    target_link_libraries(ZLIB::ZLIB INTERFACE ${target})
+    add_library(MATIO::ZLIB INTERFACE IMPORTED)
+    target_link_libraries(MATIO::ZLIB INTERFACE ${target})
     set(ZLIB_FOUND TRUE)
 endmacro()
 
@@ -86,8 +89,13 @@ if(MATIO_WITH_ZLIB)
         matio_create_zlib(hdf5::zlib-shared)
     elseif(TARGET zlib)
         matio_create_zlib(zlib)
+    elseif(TARGET ZLIB::ZLIB)
+        matio_create_zlib(ZLIB::ZLIB)
     else()
         find_package(ZLIB 1.2.3)
+        if(ZLIB_FOUND)
+            matio_create_zlib(ZLIB::ZLIB)
+        endif()
     endif()
 
     if(ZLIB_FOUND)


### PR DESCRIPTION
When using CMake 3.19.0-rc2 I get the same error that #155 tries to solve:

```
CMake Error at cmake/thirdParties.cmake:34 (add_library):
add_library cannot create imported target "HDF5::HDF5" because another target with the same name already exists.
```

I propose a different solution. Use the `MATIO` namespace for imported libraries. Also check and use the `HDF5::HDF5` and `ZLIB::ZLIB` targets if they exist.
