### PR TITLE
Fix reading 16-bit character data from MAT73 files.

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -2330,6 +2330,7 @@ Mat_VarPrint(matvar_t *matvar, int printdata)
                         }
                         break;
                     }
+                    case MAT_T_UINT8:
                     case MAT_T_UTF8: {
                         const mat_uint8_t *data = (const mat_uint8_t *)matvar->data;
                         size_t k = 0;
@@ -2378,6 +2379,18 @@ Mat_VarPrint(matvar_t *matvar, int printdata)
                             printf("\n");
                         }
                         free(idxOffset);
+                        break;
+                    }
+                    case MAT_T_UINT32:
+                    case MAT_T_UTF32: {
+                        const mat_uint32_t *data = (const mat_uint32_t *)matvar->data;
+                        for ( i = 0; i < matvar->dims[0]; i++ ) {
+                            for ( j = 0; j < matvar->dims[1]; j++ ) {
+                                const mat_uint32_t c = data[j * matvar->dims[0] + i];
+                                printf("%lc", c);
+                            }
+                            printf("\n");
+                        }
                         break;
                     }
                     default: {

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -723,8 +723,10 @@ WriteCharData(mat_t *mat, void *data, size_t N, enum matio_types data_type)
     switch ( data_type ) {
         case MAT_T_UINT8:
         case MAT_T_UINT16:
+        case MAT_T_UINT32:
         case MAT_T_UTF8:
-        case MAT_T_UTF16: {
+        case MAT_T_UTF16:
+        case MAT_T_UTF32: {
             data_type = MAT_T_UINT8 == data_type ? MAT_T_UTF8 : data_type;
             err = Mul(&nbytes, N, Mat_SizeOf(data_type));
             if ( err ) {
@@ -831,8 +833,10 @@ WriteCompressedCharData(mat_t *mat, z_streamp z, void *data, size_t N, enum mati
     switch ( data_type ) {
         case MAT_T_UINT8:
         case MAT_T_UINT16:
+        case MAT_T_UINT32:
         case MAT_T_UTF8:
         case MAT_T_UTF16:
+        case MAT_T_UTF32:
             data_tag[0] = MAT_T_UINT8 == data_type ? MAT_T_UTF8 : data_type;
             data_tag[1] = (mat_uint32_t)nbytes;
             z->next_in = ZLIB_BYTE_PTR(data_tag);

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -336,6 +336,7 @@ DataType2H5T(enum matio_types data_type)
             return H5T_NATIVE_LLONG;
 #endif
         case MAT_T_UINT32:
+        case MAT_T_UTF32:
 #if CHAR_BIT == 32
             return H5T_NATIVE_UCHAR;
 #elif CHAR_BIT * SIZEOF_SHORT == 32
@@ -1602,6 +1603,7 @@ Mat_VarWriteChar73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims)
             case MAT_T_INT32:
             case MAT_T_UINT32:
                 /* Not sure matlab will actually handle this */
+                matlab_int_decode = 4;
                 dset_id = H5Dcreate(id, name, ClassType2H5T(MAT_C_UINT32), mspace_id, H5P_DEFAULT,
                                     H5P_DEFAULT, H5P_DEFAULT);
                 break;

--- a/src/read_data.c
+++ b/src/read_data.c
@@ -344,6 +344,17 @@ ReadCompressedCharData(mat_t *mat, z_streamp z, void *data, enum matio_types dat
                 }
             }
             break;
+        case MAT_T_UINT32:
+        case MAT_T_UTF32:
+            err = InflateData(mat, z, data, (mat_uint32_t)nBytes);
+            if ( mat->byteswap ) {
+                mat_uint32_t *ptr = (mat_uint32_t *)data;
+                size_t i;
+                for ( i = 0; i < len; i++ ) {
+                    Mat_uint32Swap(&ptr[i]);
+                }
+            }
+            break;
         default:
             Mat_Warning(
                 "ReadCompressedCharData: %d is not a supported data "
@@ -383,6 +394,15 @@ ReadCharData(mat_t *mat, void *_data, enum matio_types data_type, size_t len)
             mat_uint16_t *data = (mat_uint16_t *)_data;
             mat_uint16_t v[READ_BLOCK_SIZE / sizeof(mat_uint16_t)];
             READ_DATA(mat_uint16_t, Mat_uint16Swap);
+            err = Mul(&nBytes, readcount, data_size);
+            break;
+        }
+        case MAT_T_UINT32:
+        case MAT_T_UTF32: {
+            size_t i, readcount;
+            mat_uint32_t *data = (mat_uint32_t *)_data;
+            mat_uint32_t v[READ_BLOCK_SIZE / sizeof(mat_uint32_t)];
+            READ_DATA(mat_uint32_t, Mat_uint32Swap);
             err = Mul(&nBytes, readcount, data_size);
             break;
         }


### PR DESCRIPTION
I noticed an issue when reading utf16 character data from a struct in a mat73 file. I created a mat file using the following code (based on `test_write_char_unicode` and `test_write_struct_char`);
```c++
int main(int argc, char *argv[])
{
    mat_t *mat = Mat_CreateVer("test_mat73_struct_utf16.mat", NULL, MAT_FT_MAT73);
    if ( mat == NULL)
        return 1;

    size_t num_fields = 1;
    const char *fieldnames[1] = {"field1"};
    size_t dims[2];

    dims[0] = 2;
    dims[1] = 1;
    matvar_t *struct_matvar = Mat_VarCreateStruct("struct1", 2, dims, fieldnames, num_fields);

    const mat_uint16_t str[] = {1576, 273, 1580, 105, 1604, 7879, 1740, 110};
    dims[0] = 2;
    dims[1] = 4;
    matvar_t *matvar = Mat_VarCreate(fieldnames[0], MAT_C_CHAR, MAT_T_UTF16, 2, dims, (void *)str, MAT_F_DONT_COPY_DATA);
    Mat_VarSetStructFieldByName(struct_matvar, fieldnames[0], 1, matvar);
    Mat_VarWrite(mat, struct_matvar, MAT_COMPRESSION_NONE);
    Mat_VarFree(struct_matvar);
    Mat_Close(mat);

    return 0;
}
```

The data type of `matdump test_mat73_struct_utf16.mat` is correct:
```
      Name: struct1
      Rank: 2
Class Type: Structure
Fields[1] {
      Name: field1
      Rank: 2
Dimensions: 2 x 4
Class Type: Character Array
 Data Type: 16-bit, unsigned integer
}
```

But the data type of `matdump -d test_mat73_struct_utf16.mat` is wrong:
```
      Name: struct1
      Rank: 2
Class Type: Structure
Fields[1] {
      Name: field1
      Rank: 2
Dimensions: 2 x 4
Class Type: Character Array
 Data Type: 8-bit, unsigned integer
{
ÿÿÿÿ
ÿiÿn
}
}
```

This is because `data_type` is forced to `MAT_T_UINT8`. I changed this so it now uses the actual `data_type`.
The output is now:
```
      Name: struct1
      Rank: 2
Class Type: Structure
Fields[1] {
      Name: field1
      Rank: 2
Dimensions: 2 x 4
Class Type: Character Array
 Data Type: 16-bit, unsigned integer
{
بجلی
điện
}
}
```