### PR TITLE
fix CMake properties

### DIFF
--- a/cmake/thirdParties.cmake
+++ b/cmake/thirdParties.cmake
@@ -68,7 +68,7 @@ endif()
 
 macro(matio_create_zlib target)
     add_library(MATIO::ZLIB INTERFACE IMPORTED)
-    target_link_libraries(MATIO::ZLIB INTERFACE ${target})
+    set_target_properties(MATIO::ZLIB PROPERTIES INTERFACE_LINK_LIBRARIES ${target})
     set(ZLIB_FOUND TRUE)
 endmacro()
 


### PR DESCRIPTION
Hi,

Thanks for this project :)

CMake configuration of the current master branch fails on ubuntu 18.04, because:
```cmake
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found suitable version "1.2.11", minimum required is "1.2.3") 
CMake Error at cmake/thirdParties.cmake:71 (target_link_libraries):
  Cannot specify link libraries for target "MATIO::ZLIB" which is not built
  by this project.
Call Stack (most recent call first):
  cmake/thirdParties.cmake:97 (matio_create_zlib)
  CMakeLists.txt:29 (include)
```

Here is a simple Dockerfile to reproduce this issue:
```Dockerfile
FROM ubuntu:18.04

RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
    --mount=type=cache,sharing=locked,target=/var/lib/apt \
    apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -qqy \
    build-essential \
    git \
    cmake \
    libhdf5-dev \
    zlib1g-dev

WORKDIR /src
RUN git clone --recursive https://github.com/tbeu/matio
RUN cmake -B build -S matio
```