### PR TITLE
CMake: fix version comparison

### DIFF
--- a/cmake/compilerOptions.cmake
+++ b/cmake/compilerOptions.cmake
@@ -89,7 +89,7 @@ check_c_source_compiles("${TEST_CODE_THOUSANDS_SEP}" HAVE_STRUCT_LCONV_THOUSANDS
 set(USE_GNU_LINK_FLAGS 0)
 set(USE_LLVM_MACOS_LINK_FLAGS 0)
 if (NOT MSVC)
-    if(${CMAKE_VERSION} GREATER "3.17")
+    if(${CMAKE_VERSION} VERSION_GREATER "3.17")
         include(CheckLinkerFlag)
         check_linker_flag(C "-Wl,--no-undefined" HAVE_LINK_NO_UNDEFINED)
         check_linker_flag(C "-Wl,-undefined,error" HAVE_LINK_UNDEFINED_ERROR)


### PR DESCRIPTION
Hi again,

On CentOS 7, with CMake 3.7.2, I get the following issue:
```
CMake Error at cmake/compilerOptions.cmake:93 (include):
include could not find load file:

CheckLinkerFlag
Call Stack (most recent call first):
CMakeLists.txt:30 (include)


CMake Error at cmake/compilerOptions.cmake:94 (check_linker_flag):
Unknown CMake command "check_linker_flag".
Call Stack (most recent call first):
CMakeLists.txt:30 (include)
```