### PR TITLE
fix autoconf getopt_long check

### DIFF
--- a/config/matio_getopt_long.m4
+++ b/config/matio_getopt_long.m4
@@ -5,12 +5,15 @@ AC_MSG_CHECKING(for getopt_long)
 
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>
  #include <stdlib.h>
+ #ifdef HAVE_STDDEF_H
+ #include <stddef.h>
+ #endif
  #ifdef HAVE_UNISTD_H
  #include <unistd.h>
  #endif
  #define _GNU_SOURCE /* For getopt_long on GNU systems */
  #include <getopt.h>
-]], [[opt = getopt_long(0,NULL,NULL,NULL,NULL);]])],[ac_have_getopt_long=yes],[ac_have_getopt_long=no])
+]], [[int opt = getopt_long(0,NULL,NULL,NULL,NULL);]])],[ac_have_getopt_long=yes],[ac_have_getopt_long=no])
 
 if test "x$ac_have_getopt_long" = "xyes"
 then


### PR DESCRIPTION
NULL is defined in stddef.h according to the C11 standard, so include it if it exists. opt is missing its data type so compilation of the code always fails. Fix it by adding int, the return type of getopt_long.