### PR TITLE
Introduce predicated iteration functions

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -2794,7 +2794,7 @@ Mat_VarReadNextPredicate(mat_t *mat, mat_iter_pred_t pred, const void *user_data
             }
             break;
         }
-    } while (pred && pred(matvar->name, user_data) == 0);  // for 7.3 the predicate will be called one extra time
+    } while (pred && pred(matvar->name, user_data) == 0);  /* for 7.3 the predicate will be called one extra time */
 
     return matvar;
 }

--- a/src/mat.c
+++ b/src/mat.c
@@ -2766,7 +2766,8 @@ Mat_VarReadNext(mat_t *mat)
  * variable information
  */
 matvar_t *
-Mat_VarReadNextPredicate(mat_t *mat, mat_iter_pred_t pred, const void *user_data) {
+Mat_VarReadNextPredicate(mat_t *mat, mat_iter_pred_t pred, const void *user_data)
+{
     mat_off_t fpos = 0;
     matvar_t *matvar = NULL;
 
@@ -2794,7 +2795,8 @@ Mat_VarReadNextPredicate(mat_t *mat, mat_iter_pred_t pred, const void *user_data
             }
             break;
         }
-    } while (pred && pred(matvar->name, user_data) == 0);  /* for 7.3 the predicate will be called one extra time */
+    } while ( pred && pred(matvar->name, user_data) ==
+                          0 ); /* for 7.3 the predicate will be called one extra time */
 
     return matvar;
 }

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -3201,7 +3201,8 @@ Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info, v
     /* Check that this is not the /#refs# or /"#subsystem#" group */
     if ( 0 == strcmp(name, "#refs#") || 0 == strcmp(name, "#subsystem#") )
         return 0;
-    if (mat_data && mat_data->pred && mat_data->pred(name, mat_data->pred_user_data) == 0)  /* do we need to skip it? */
+    if ( mat_data && mat_data->pred &&
+         mat_data->pred(name, mat_data->pred_user_data) == 0 ) /* do we need to skip it? */
         return 0;
 
     object_info.type = H5O_TYPE_UNKNOWN;

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <time.h>
+#include <errno.h>
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #define strdup _strdup
 #endif
@@ -53,6 +54,8 @@ struct ReadNextIterData
 {
     mat_t *mat;
     matvar_t *matvar;
+    mat_iter_pred_t pred;
+    const void *pred_user_data;
 };
 
 struct ReadGroupInfoIterData
@@ -3158,7 +3161,7 @@ Mat_VarReadDataLinear73(mat_t *mat, matvar_t *matvar, void *data, int start, int
  * @endif
  */
 matvar_t *
-Mat_VarReadNextInfo73(mat_t *mat)
+Mat_VarReadNextInfo73(mat_t *mat, mat_iter_pred_t pred, const void *user_data)
 {
     hid_t id;
     hsize_t idx;
@@ -3175,6 +3178,8 @@ Mat_VarReadNextInfo73(mat_t *mat)
     idx = (hsize_t)mat->next_index;
     mat_data.mat = mat;
     mat_data.matvar = NULL;
+    mat_data.pred = pred;
+    mat_data.pred_user_data = user_data;
     herr = H5Literate(id, H5_INDEX_NAME, H5_ITER_NATIVE, &idx, Mat_VarReadNextInfoIterate,
                       (void *)&mat_data);
     if ( herr > 0 )
@@ -3191,8 +3196,12 @@ Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info, v
 
     /* FIXME: follow symlinks, datatypes? */
 
+    mat_data = (struct ReadNextIterData *)op_data;
+
     /* Check that this is not the /#refs# or /"#subsystem#" group */
     if ( 0 == strcmp(name, "#refs#") || 0 == strcmp(name, "#subsystem#") )
+        return 0;
+    if (mat_data && mat_data->pred && mat_data->pred(name, mat_data->pred_user_data) == 0)  // do we need to skip it?
         return 0;
 
     object_info.type = H5O_TYPE_UNKNOWN;
@@ -3200,7 +3209,6 @@ Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info, v
     if ( H5O_TYPE_DATASET != object_info.type && H5O_TYPE_GROUP != object_info.type )
         return 0;
 
-    mat_data = (struct ReadNextIterData *)op_data;
     if ( NULL == mat_data )
         return -1;
     mat = mat_data->mat;

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -3201,7 +3201,7 @@ Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info, v
     /* Check that this is not the /#refs# or /"#subsystem#" group */
     if ( 0 == strcmp(name, "#refs#") || 0 == strcmp(name, "#subsystem#") )
         return 0;
-    if (mat_data && mat_data->pred && mat_data->pred(name, mat_data->pred_user_data) == 0)  // do we need to skip it?
+    if (mat_data && mat_data->pred && mat_data->pred(name, mat_data->pred_user_data) == 0)  /* do we need to skip it? */
         return 0;
 
     object_info.type = H5O_TYPE_UNKNOWN;

--- a/src/mat73.h
+++ b/src/mat73.h
@@ -41,7 +41,7 @@ EXTERN int Mat_VarReadData73(mat_t *mat, matvar_t *matvar, void *data, int *star
                              int *edge);
 EXTERN int Mat_VarReadDataLinear73(mat_t *mat, matvar_t *matvar, void *data, int start, int stride,
                                    int edge);
-EXTERN matvar_t *Mat_VarReadNextInfo73(mat_t *mat);
+EXTERN matvar_t *Mat_VarReadNextInfo73(mat_t *mat, mat_iter_pred_t pred, const void *user_data);
 EXTERN int Mat_VarWrite73(mat_t *mat, matvar_t *matvar, int compress);
 EXTERN int Mat_VarWriteAppend73(mat_t *mat, matvar_t *matvar, int compress, int dim);
 

--- a/src/matio.h
+++ b/src/matio.h
@@ -261,6 +261,12 @@ typedef struct mat_sparse_t
 #define MATIO_E_FILESYSTEM_ERROR_ON_CLOSE 24
 /** @endcond */
 
+/**
+ * User callback for iteration functions.
+ * returns 1 to read, 0 to skip
+ */
+typedef int (*mat_iter_pred_t)(const char *name, const void *user_data);
+
 /* Library function */
 EXTERN void Mat_GetLibraryVersion(int *major, int *minor, int *release);
 
@@ -327,7 +333,9 @@ EXTERN int Mat_VarReadDataLinear(mat_t *mat, matvar_t *matvar, void *data, int s
                                  int edge);
 EXTERN matvar_t *Mat_VarReadInfo(mat_t *mat, const char *name);
 EXTERN matvar_t *Mat_VarReadNext(mat_t *mat);
+EXTERN matvar_t *Mat_VarReadNextPredicate(mat_t *mat, mat_iter_pred_t pred, const void *user_data);
 EXTERN matvar_t *Mat_VarReadNextInfo(mat_t *mat);
+EXTERN matvar_t *Mat_VarReadNextInfoPredicate(mat_t *mat, mat_iter_pred_t pred, const void *user_data);
 EXTERN matvar_t *Mat_VarSetCell(matvar_t *matvar, int index, matvar_t *cell);
 EXTERN matvar_t *Mat_VarSetStructFieldByIndex(matvar_t *matvar, size_t field_index, size_t index,
                                               matvar_t *field);

--- a/src/matio.h
+++ b/src/matio.h
@@ -335,7 +335,8 @@ EXTERN matvar_t *Mat_VarReadInfo(mat_t *mat, const char *name);
 EXTERN matvar_t *Mat_VarReadNext(mat_t *mat);
 EXTERN matvar_t *Mat_VarReadNextPredicate(mat_t *mat, mat_iter_pred_t pred, const void *user_data);
 EXTERN matvar_t *Mat_VarReadNextInfo(mat_t *mat);
-EXTERN matvar_t *Mat_VarReadNextInfoPredicate(mat_t *mat, mat_iter_pred_t pred, const void *user_data);
+EXTERN matvar_t *Mat_VarReadNextInfoPredicate(mat_t *mat, mat_iter_pred_t pred,
+                                              const void *user_data);
 EXTERN matvar_t *Mat_VarSetCell(matvar_t *matvar, int index, matvar_t *cell);
 EXTERN matvar_t *Mat_VarSetStructFieldByIndex(matvar_t *matvar, size_t field_index, size_t index,
                                               matvar_t *field);


### PR DESCRIPTION
Reading a Matio variable from an HDF5 files sometimes can be too slow. Besides it's often necessary to iterate over all variable to read just one. This takes a lot of time. This change allows to skip unnecessary readings