### PR TITLE
Fix Heap-buffer-overflow WRITE in H5MM_memcpy

### DIFF
--- a/src/mat73.c
+++ b/src/mat73.c
@@ -644,10 +644,10 @@ Mat_H5ReadFieldNames(matvar_t *matvar, hid_t dset_id, hsize_t *nfields)
         H5Aclose(attr_id);
         return MATIO_E_GENERIC_READ_ERROR;
     } else {
+        if ( err == 0 ) {
+            *nfields = 1;
+        }
         err = MATIO_E_NO_ERROR;
-    }
-    if ( err == 0 ) {
-        *nfields = 1;
     }
     fieldnames_vl = (hvl_t *)calloc((size_t)(*nfields), sizeof(*fieldnames_vl));
     if ( fieldnames_vl == NULL ) {

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -646,6 +646,8 @@ Mat_H5ReadFieldNames(matvar_t *matvar, hid_t dset_id, hsize_t *nfields)
     } else {
         err = MATIO_E_NO_ERROR;
     }
+    if (*nfields == 0)
+        *nfields = 1;
     fieldnames_vl = (hvl_t *)calloc((size_t)(*nfields), sizeof(*fieldnames_vl));
     if ( fieldnames_vl == NULL ) {
         H5Sclose(space_id);

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -646,8 +646,9 @@ Mat_H5ReadFieldNames(matvar_t *matvar, hid_t dset_id, hsize_t *nfields)
     } else {
         err = MATIO_E_NO_ERROR;
     }
-    if (*nfields == 0)
+    if ( *nfields == 0 ) {
         *nfields = 1;
+    }
     fieldnames_vl = (hvl_t *)calloc((size_t)(*nfields), sizeof(*fieldnames_vl));
     if ( fieldnames_vl == NULL ) {
         H5Sclose(space_id);

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -646,7 +646,7 @@ Mat_H5ReadFieldNames(matvar_t *matvar, hid_t dset_id, hsize_t *nfields)
     } else {
         err = MATIO_E_NO_ERROR;
     }
-    if ( *nfields == 0 ) {
+    if ( err == 0 ) {
         *nfields = 1;
     }
     fieldnames_vl = (hvl_t *)calloc((size_t)(*nfields), sizeof(*fieldnames_vl));


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58262

The root cause is that `H5Sget_simple_extent_dims` doesn't fail and doesn't initialize `*nfields` for scalar types, so it is left zero. Behavior of `calloc` call with zero size is implementation dependent, but in this case it returns a non null memory which is valid to use only with `free`.
