### PR TITLE
Use latest hdf5 for fuzzing

### DIFF
--- a/ossfuzz/build.sh
+++ b/ossfuzz/build.sh
@@ -22,10 +22,18 @@ make -j$(nproc) CFLAGS="$CFLAGS -fPIC"
 make install
 popd
 
+wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz
+tar xvfvz autoconf-2.71.tar.gz
+pushd autoconf-2.71
+./configure
+make
+make install
+popd
+
 #build hdf5
 pushd "$SRC"
-tar -xvf hdf5-1.12.1.tar.gz
-cd hdf5-1.12.1
+cd hdf5
+./autogen.sh
 ./configure --disable-shared --disable-deprecated-symbols --disable-hl --disable-parallel --disable-trace --disable-internal-debug --disable-asserts --disable-tests --disable-tools --with-pic --with-zlib="$WORK" --prefix="$WORK"
 make -j$(nproc)
 make install


### PR DESCRIPTION
The following OSS-Fuzz issues are not reproducible with the latest HDF5. I.e. most probably were found and fixed independently. By fuzzing with the latest version of HDF5 they will be automatically closed in OSS-Fuzz.

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29776
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53690
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37185
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41590
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39869
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38041
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45177
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37536
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30749
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38686
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41318
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30184
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37318
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41576
