### PR TITLE
Avoid crashes with corrupted files

### DIFF
--- a/src/mat5.c
+++ b/src/mat5.c
@@ -1696,7 +1696,7 @@ ReadNextStructField(mat_t *mat, matvar_t *matvar)
                     if ( 0 == err ) {
                         SetFieldNames(matvar, ptr, nfields, fieldname_size);
                     } else {
-                        matvar->internal->num_fields = nfields;
+                        matvar->internal->num_fields = 0;
                         matvar->internal->fieldnames = NULL;
                     }
                     free(ptr);

--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -130,12 +130,12 @@ Mat_VarAddStructField(matvar_t *matvar, const char *fieldname)
     if ( err )
         return -1;
 
-    matvar->internal->num_fields++;
-    nfields = matvar->internal->num_fields;
+    nfields = matvar->internal->num_fields + 1;
     fieldnames = (char **)realloc(matvar->internal->fieldnames,
                                   nfields * sizeof(*matvar->internal->fieldnames));
     if ( NULL == fieldnames )
         return -1;
+    matvar->internal->num_fields = nfields;
     matvar->internal->fieldnames = fieldnames;
     matvar->internal->fieldnames[nfields - 1] = strdup(fieldname);
 
@@ -221,7 +221,7 @@ Mat_VarGetStructFieldByIndex(matvar_t *matvar, size_t field_index, size_t index)
     matvar_t *field = NULL;
     size_t nelems = 1, nfields;
 
-    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT || matvar->data_size == 0 )
+    if ( matvar == NULL || matvar->data == NULL || matvar->class_type != MAT_C_STRUCT || matvar->data_size == 0 )
         return NULL;
 
     err = Mat_MulDims(matvar, &nelems);
@@ -259,7 +259,7 @@ Mat_VarGetStructFieldByName(matvar_t *matvar, const char *field_name, size_t ind
     matvar_t *field = NULL;
     size_t nelems = 1;
 
-    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT || matvar->data_size == 0 )
+    if ( matvar == NULL || matvar->data == NULL || matvar->class_type != MAT_C_STRUCT || matvar->data_size == 0 )
         return NULL;
 
     err = Mat_MulDims(matvar, &nelems);


### PR DESCRIPTION
Our customers quite often come with corrupted files which lead to crashes somewhere in Matio.
This PR fixes the crashes we discovered so far. 