### PR TITLE
Fix LFS support on MinGW 64bit builds

### DIFF
--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -41,18 +41,19 @@
 #endif
 
 #if defined(__BORLANDC__) || defined(__MINGW32__) || defined(_MSC_VER)
-#define mat_off_t __int64
 #if defined(_MSC_VER) && defined(HAVE__FSEEKI64) && defined(HAVE__FTELLI64)
 #define MATIO_LFS
+#define mat_off_t __int64
 #define fseeko _fseeki64
 #define ftello _ftelli64
 #elif defined(__BORLANDC__) && defined(HAVE__FSEEKI64) && defined(HAVE__FTELLI64)
 #define MATIO_LFS
+#define mat_off_t __int64
 #define fseeko _fseeki64
 #define ftello _ftelli64
-#elif !defined(HAVE_FSEEKO) && !defined(HAVE_FTELLO) && defined(HAVE_FSEEKO64) && \
-    defined(HAVE_FTELLO64)
+#elif defined(HAVE_FSEEKO64) && defined(HAVE_FTELLO64)
 #define MATIO_LFS
+#define mat_off_t __int64
 #define fseeko fseeko64
 #define ftello ftello64
 #endif


### PR DESCRIPTION
The primary change is to drop the
!defined(HAVE_FSEEKO) && !defined(HAVE_FTELLO) from the corresponding condition, as MinGW defines both fseeko and fseeko64, and it doesn't really make sense to not always use the 64bit versions when available.

The other change is that the '#define mat_off_t __int64' is moved into the inner conditions of the Windows check, so that if no inner condition is applicable, the later default definition in the header doesn't clash with the previous definition.