### PR TITLE
Windows: don't check for MSVC for supporting Unicode filenames

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -29,7 +29,7 @@
  */
 
 #include "matio_private.h"
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOGDI
 #include <Windows.h>
@@ -75,7 +75,7 @@ strdup_vprintf(const char *format, va_list ap)
     return buffer;
 }
 
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
 /** @brief Convert from narrow UTF-8 string to wide string
  *
  * @ingroup mat_util

--- a/src/mat.c
+++ b/src/mat.c
@@ -483,7 +483,7 @@ Mat_Open(const char *matname, int mode)
     size_t bytesread = 0;
 
     if ( (mode & 0x01) == MAT_ACC_RDONLY ) {
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
         wchar_t *wname = utf82u(matname);
         if ( NULL != wname ) {
             fp = _wfopen(wname, L"rb");
@@ -497,7 +497,7 @@ Mat_Open(const char *matname, int mode)
             return NULL;
         }
     } else if ( (mode & 0x01) == MAT_ACC_RDWR ) {
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
         wchar_t *wname = utf82u(matname);
         if ( NULL != wname ) {
             fp = _wfopen(wname, L"r+b");
@@ -1262,7 +1262,7 @@ Mat_CopyFile(const char *src, const char *dst)
     FILE *in = NULL;
     FILE *out = NULL;
 
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
     {
         wchar_t *wname = utf82u(src);
         if ( NULL != wname ) {
@@ -1278,7 +1278,7 @@ Mat_CopyFile(const char *src, const char *dst)
         return MATIO_E_FILESYSTEM_COULD_NOT_OPEN;
     }
 
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
     {
         wchar_t *wname = utf82u(dst);
         if ( NULL != wname ) {

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -59,7 +59,7 @@ Mat_Create4(const char *matname)
     FILE *fp = NULL;
     mat_t *mat = NULL;
 
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
     wchar_t *wname = utf82u(matname);
     if ( NULL != wname ) {
         fp = _wfopen(wname, L"w+b");

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -635,7 +635,7 @@ Mat_Create5(const char *matname, const char *hdr_str)
     size_t err;
     time_t t;
 
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
     wchar_t *wname = utf82u(matname);
     if ( NULL != wname ) {
         fp = _wfopen(wname, L"w+b");

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -2547,7 +2547,7 @@ Mat_Create73(const char *matname, const char *hdr_str)
     H5Fclose(fid);
     H5Pclose(plist_id);
 
-#if defined(_WIN32) && defined(_MSC_VER) && H5_VERSION_GE(1, 11, 6)
+#if defined(_WIN32) && H5_VERSION_GE(1, 11, 6)
     {
         wchar_t *wname = utf82u(matname);
         if ( NULL != wname ) {

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -266,7 +266,7 @@ EXTERN int IsEndOfFile(FILE *fp, mat_off_t *fpos);
 EXTERN int CheckSeekFile(FILE *fp, mat_off_t offset);
 
 /* io.c */
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
 EXTERN wchar_t *utf82u(const char *src);
 #endif
 


### PR DESCRIPTION
The corresponding wchar_t functionality is also supported by MinGW (at least somewhat recent versions thereof), so the check for _MSC_VER causes the MinGW build to only support the local codepage, and thus differ from the MSVC build, and also have the issue of not being able to access some files on the filesystem if they are not representable in the local codepage.

This drops the defined(_MSC_VER) and only keeps the _WIN32 check, because this is not a compiler feature, but rather a platform feature, so that check is the correct one.

This patch has been used in production successfully for quite a while with MinGW builds.