### PR TITLE
HDF5-based format: update detection of HDF5 version for UTF-8-based filenames

### DIFF
--- a/src/mat73.c
+++ b/src/mat73.c
@@ -2548,7 +2548,7 @@ Mat_Create73(const char *matname, const char *hdr_str)
     H5Fclose(fid);
     H5Pclose(plist_id);
 
-#if defined(_WIN32) && H5_VERSION_GE(1, 11, 6)
+#if defined(_WIN32) && H5_VERSION_GE(1, 10, 6)
     {
         wchar_t *wname = utf82u(matname);
         if ( NULL != wname ) {


### PR DESCRIPTION
As discussed in https://github.com/tbeu/matio/pull/236 here is the dependent change that updates the minimum HDF5 version to 1.10.6. The commit message contains a longer explanation for the rationale behind the change.