### PR TITLE
Fix divide-by-zero in Mat_VarReadDataLinear73 when dims contains zero

### DIFF
--- a/src/mat73.c
+++ b/src/mat73.c
@@ -3532,8 +3532,18 @@ Mat_VarReadDataLinear73(mat_t *mat, matvar_t *matvar, void *data, int start, int
                 break;
             }
             dimp[0] = 1;
-            for ( k = 1; k < matvar->rank; k++ )
+            for ( k = 1; k < matvar->rank; k++ ) {
+                if ( matvar->dims[k - 1] == 0 ) {
+                    err = MATIO_E_FILE_FORMAT_VIOLATION;
+                    free(points);
+                    free(dimp);
+                    break;
+                }
                 dimp[k] = dimp[k - 1] * matvar->dims[k - 1];
+            }
+            if ( err ) {
+                break;
+            }
             for ( k = 0; k < edge; k++ ) {
                 size_t l, coord;
                 coord = (size_t)(start + k * stride);


### PR DESCRIPTION
## Summary
- When reading a v7.3 dataset with `rank > 1`, `Mat_VarReadDataLinear73` computes a cumulative-product array `dimp[]` from `matvar->dims[]`. If any `dims[k]` is 0 (possible with attacker-controlled v7.3 metadata), all subsequent `dimp[k]` entries become 0 and the later `coord / dimp[l]` divides by zero, crashing with SIGFPE.
- This patch validates `dims[k] > 0` before the `dimp[]` computation and returns `MATIO_E_FILE_FORMAT_VIOLATION` if any dimension is zero.