### PR TITLE
Bounds-check index in Mat_VarGetCellsLinear

### DIFF
--- a/src/matvar_cell.c
+++ b/src/matvar_cell.c
@@ -135,11 +135,18 @@ Mat_VarGetCellsLinear(const matvar_t *matvar, int start, int stride, int edge)
 {
     matvar_t **cells = NULL;
 
-    if ( matvar != NULL ) {
+    if ( matvar != NULL && matvar->data != NULL && edge > 0 ) {
         int i, I;
+        size_t ndata = matvar->nbytes / sizeof(matvar_t *);
         cells = (matvar_t **)malloc(edge * sizeof(matvar_t *));
+        if ( cells == NULL )
+            return NULL;
         I = start;
         for ( i = 0; i < edge; i++ ) {
+            if ( I < 0 || (size_t)I >= ndata ) {
+                free(cells);
+                return NULL;
+            }
             cells[i] = *((matvar_t **)matvar->data + I);
             I += stride;
         }


### PR DESCRIPTION
## Summary
- `Mat_VarGetCellsLinear` dereferences `matvar->data + I` without verifying `I` against the actual allocated size of the data buffer. For a malformed cell array where the file's `dims` claim more elements than were actually parsed (truncated read), a caller that respects the API contract can still trigger a heap-buffer-overflow READ.
- This patch computes the actual capacity from `matvar->nbytes / sizeof(matvar_t *)` and bounds-checks `I` inside the loop, returning `NULL` if any index is out of range. Also adds null checks for `matvar->data` and the `malloc` return.