### PR TITLE
Avoid uninitialized memory access in Mat_GetDir

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -1050,7 +1050,7 @@ Mat_GetDir(mat_t *mat, size_t *n)
                 if ( NULL != matvar ) {
                     if ( NULL != matvar->name ) {
                         if ( NULL == mat->dir ) {
-                            dir = (char **)malloc(sizeof(char *));
+                            dir = (char **)calloc(1, sizeof(char *));
                         } else {
                             dir = (char **)realloc(mat->dir,
                                                    (mat->num_datasets + 1) * (sizeof(char *)));


### PR DESCRIPTION
## Summary
- `Mat_GetDir` allocates the initial directory pointer via `malloc(sizeof(char *))`. If the subsequent `strdup` fails or a code path skips the assignment, the slot contains uninitialized memory. Callers that iterate over `dir[]` checking for NULL then read uninitialized data.
- Use `calloc` instead so unwritten slots are zero-initialized (NULL).

Found by OSS-Fuzz (`matio_fuzzer` + MSan).