### PR TITLE
Added cmake install package

### DIFF
--- a/cmake/src.cmake
+++ b/cmake/src.cmake
@@ -62,11 +62,12 @@ endif()
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}
-    INTERFACE ${PROJECT_SOURCE_DIR}/src
-    PUBLIC    ${PROJECT_BINARY_DIR}/src
+    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    PUBLIC    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+              $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 if(STDINT_MSVC)
-    target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/visual_studio)
+    target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/visual_studio>)
 endif()
 
 if(HAVE_LIBM)
@@ -79,7 +80,7 @@ if(MSVC)
 endif()
 
 if(MATIO_WITH_HDF5 AND HDF5_FOUND)
-    target_link_libraries(${PROJECT_NAME} PUBLIC MATIO::HDF5)
+    target_link_libraries(${PROJECT_NAME} PRIVATE MATIO::HDF5)
 endif()
 
 if(MATIO_WITH_ZLIB AND ZLIB_FOUND)
@@ -118,4 +119,23 @@ install(TARGETS ${PROJECT_NAME} EXPORT lib${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
+  EXPORT "lib${PROJECT_NAME}"
+  FILE "${PROJECT_NAME}.cmake"
+  DESTINATION "cmake"
+)
+
+include(CMakePackageConfigHelpers)
+
+set(MATIO_EXPORT_NAME "${PROJECT_NAME}")
+configure_package_config_file(
+  "matio.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "cmake"
+)
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  DESTINATION "cmake"
 )

--- a/matio.cmake.in
+++ b/matio.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@MATIO_EXPORT_NAME@.cmake")


### PR DESCRIPTION
I added this to install matio as a cmake package.
Using find_package on the installed config worked for me when using with a static lib as well as an executable.
For that i also added code to differentiate between build time and install time.

Other than that i linked the hdf5 wrapper target private instead of public, as matio does not build hdf5 itsself and does not depend on it in the public api afaik.