### PR TITLE
Enable support for zlib-ng in compat mode

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -172,6 +172,29 @@ jobs:
             cmake --build build -- -j8
             ctest --no-tests=error --test-dir build --build-config Release --parallel 8
 
+  build-zlib-ng:
+    name: linux-gcc (zlib-ng)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 5
+          submodules: recursive
+      - name: Setup python environment
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+      - name: Install python packages
+        run: pip install --disable-pip-version-check --user "conan>=2.16.1,<3"
+      - name: Configure with zlib-ng (zlib compat mode)
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider -DCONAN_HOST_PROFILE="default;auto-cmake;${{ github.workspace }}/.ci/conan_static_profile_linux-gcc.cmake" -DMATIO_SHARED=OFF -DMATIO_USE_ZLIB_NG=ON -DMATIO_MAT73=OFF -DMATIO_WITH_ZLIB=ON -DMATIO_EXTENDED_SPARSE=ON -DMATIO_MCOS=ON
+      - name: Build with gcc
+        run: cmake --build build -- -j8
+      - name: Test
+        run: ctest --no-tests=error --test-dir build --build-config Release --parallel 8
+
   build-cygwin:
     name: windows-cygwin
     runs-on: windows-latest

--- a/README
+++ b/README
@@ -75,6 +75,9 @@ Table of Contents
         2.1.1 zlib
             To support compressed MAT files, zlib 1.2.3 or greater is required.
             The zlib software can be downloaded from https://zlib.net/.
+            As an alternative, zlib-ng (https://github.com/zlib-ng/zlib-ng) can be used
+            as a drop-in replacement. Enable the MATIO_USE_ZLIB_NG CMake option or set
+            the ZLIBNG_ROOT hint to locate the zlib-ng installation.
 
         2.1.2 HDF5
             Support for MAT file version 7.3 requires the HDF5 library of
@@ -220,6 +223,14 @@ Table of Contents
               * 'MATIO_USE_CONAN:BOOL=OFF'
                 This deprecated option enables the Conan 1.X package manager to
                 resolve the library dependencies.
+              * 'MATIO_USE_ZLIB_NG:BOOL=OFF'
+                This option enables zlib-ng as an alternative zlib
+                implementation. When enabled, CMake searches for a
+                system-installed zlib-ng first, and falls back to building
+                zlib-ng from source via 'FetchContent'. zlib-ng is always used
+                in zlib compatibility mode ('ZLIB_COMPAT=ON'), which provides
+                the standard zlib API headers and types. Set 'ZLIBNG_ROOT' to a
+                directory containing a zlib-ng installation.
 
             To help CMake find the HDF5 libraries, set environment variable
             HDF5_DIR to the 'cmake/hdf5' directory (containing 'hdf5-config.cmake')

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Matio has two optional dependencies. These are not required for the software to 
 
 #### 2.1.1 zlib
 To support compressed MAT files, zlib version &ge; 1.2.3 is required. The zlib software can be downloaded from https://zlib.net/.
+As an alternative, [zlib-ng](https://github.com/zlib-ng/zlib-ng) can be used as a drop-in replacement. Enable the `MATIO_USE_ZLIB_NG` CMake option or set the `ZLIBNG_ROOT` hint to locate the zlib-ng installation.
 
 #### 2.1.2 HDF5
 Support for MAT file version 7.3 requires the HDF5 library of version &ge; 1.8.x. This library can be downloaded from https://github.com/HDFGroup/hdf5/releases.  Neither deprecated HDF5 1.6.x API functions nor HDF5 higher-level functions are called.
@@ -144,6 +145,8 @@ This option builds the matio library as shared object (i.e., a dynamic link libr
 This option enables CMake to check for availability of the HDF5 library (see section [2.1.2](#212-hdf5) for information about HDF5).
 * `MATIO_WITH_ZLIB:BOOL=ON`
 This option enables CMake to check for availability of the zlib library (see section [2.1.1](#211-zlib) for information about zlib).
+* `MATIO_USE_ZLIB_NG:BOOL=OFF`
+This option enables zlib-ng as an alternative zlib implementation (see section [2.1.1](#211-zlib) for information about zlib). When enabled, CMake searches for a system-installed zlib-ng first, and falls back to building zlib-ng from source via `FetchContent`. zlib-ng is always used in zlib compatibility mode (`ZLIB_COMPAT=ON`), which provides the standard zlib API headers and types. Set `ZLIBNG_ROOT` to a directory containing a zlib-ng installation.
 * `MATIO_BUILD_TESTING:BOOL=ON`
 This option enables the matio testsuite for CTest.
 * `MATIO_MATLAB:BOOL=OFF`
@@ -164,6 +167,8 @@ This deprecated option enables the Conan 1.X package manager to resolve the libr
 To help CMake find the HDF5 libraries, set environment variable `HDF5_DIR` to the `cmake/hdf5` directory (containing `hdf5-config.cmake`) inside the HDF5 build or installation directory, or call CMake with `-DHDF5_DIR="dir/to/hdf5/cmake/hdf5"`. Alternatively call CMake with `-DCMAKE_PREFIX_PATH="dir/to/hdf5/cmake"`. See the [HDF5 documentation](https://support.hdfgroup.org/documentation/index.html) for more information. Using `hdf5-config` is recommended over using CMake's built-in `FindHDF5`, especially for static builds. CMake 3.10 or later is recommended.
 
 For Conan 2.X as dependency provider call CMake with `-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider`. CMake 3.24 or later is required.
+
+To help CMake find zlib-ng (when `MATIO_USE_ZLIB_NG=ON`), set the environment variable `ZLIBNG_ROOT` to the zlib-ng installation prefix, or call CMake with `-DZLIBNG_ROOT="dir/to/zlib-ng"`.
 
 #### 2.2.4 Visual Studio
 Visual Studio solutions are provided as [matio_vs2008.sln](visual_studio/matio_vs2008.sln) for VS2008 and as [matio.sln](visual_studio/matio.sln) for VS2010 (and newer). The Debug and Release configurations of both solutions are set up to build a DLL of the matio library (libmatio.dll) and the matdump tool and assume HDF5 is available in the directory specified by the HDF5_DIR environment variable. It is assumed that the **shared** libraries of HDF5 (and zlib) are available. If the **static** libraries of HDF5 (and zlib) are installed/built the macro `H5_BUILT_AS_STATIC_LIB` needs to be defined (instead of `H5_BUILT_AS_DYNAMIC_LIB`). Furthermore, the Release Lib configuration of the VS2010 solution is set up to build a static LIB of the matio library (libmatio.lib) and assumes that the **static** libraries of HDF5 (and zlib) are installed/built.

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -27,6 +27,9 @@ option(MATIO_WITH_HDF5 "Check for hdf5 library" ON)
 # Build with zlib support
 option(MATIO_WITH_ZLIB "Check for zlib library" ON)
 
+# Option to use zlib-ng as an alternative zlib implementation
+option(MATIO_USE_ZLIB_NG "Use zlib-ng library instead of zlib" OFF)
+
 # Select what MAT file format version is used by default
 set(MATIO_DEFAULT_FILE_VERSION "5" CACHE STRING "Default MAT file version")
 set_property(CACHE MATIO_DEFAULT_FILE_VERSION PROPERTY STRINGS 4 5 7.3)

--- a/cmake/thirdParties.cmake
+++ b/cmake/thirdParties.cmake
@@ -90,7 +90,53 @@ macro(MATIO_CREATE_ZLIB target)
     set(ZLIB_FOUND TRUE)
 endmacro()
 
-if(MATIO_WITH_ZLIB)
+# Try zlib-ng first if requested (as alternative to regular zlib)
+if(MATIO_USE_ZLIB_NG AND MATIO_WITH_ZLIB)
+    include(FetchContent)
+
+    # Try zlib-ng via its own CMake config file first.
+    # zlib-ng must be in zlib compatibility mode (ZLIB_COMPAT) for matio,
+    # which uses standard zlib types (z_streamp, inflate, etc.)
+    find_package(zlib-ng QUIET CONFIG)
+    if(zlib-ng_FOUND)
+        if(TARGET ZLIB::ZLIB)
+            MATIO_CREATE_ZLIB("ZLIB::ZLIB")
+        elseif(TARGET ZLIB::zlibstatic)
+            MATIO_CREATE_ZLIB("ZLIB::zlibstatic")
+        elseif(TARGET zlib-ng::zlib AND TARGET zlib)
+            # zlib-ng with ZLIB_ALIASES and ZLIB_COMPAT
+            MATIO_CREATE_ZLIB(zlib)
+        elseif(TARGET zlib-ng::zlibstatic AND TARGET zlibstatic)
+            MATIO_CREATE_ZLIB(zlibstatic)
+        else()
+            message(FATAL_ERROR
+                "zlib-ng found but not built with zlib compatibility. "
+                "Set MATIO_USE_ZLIB_NG=OFF or rebuild zlib-ng with -DZLIB_COMPAT=ON."
+            )
+        endif()
+    else()
+        # Fallback: fetch and build zlib-ng from source (always in compat mode)
+        message(STATUS "zlib-ng not found on system, fetching from GitHub")
+        FetchContent_Declare(zlib-ng
+            GIT_REPOSITORY https://github.com/zlib-ng/zlib-ng
+            GIT_TAG        12731092979c6d07f42da27da673a9f6c7b13586
+            GIT_SHALLOW    TRUE
+        )
+        set(ZLIB_COMPAT ON CACHE BOOL "Build zlib-ng with zlib compatibility" FORCE)
+        set(ZLIB_ENABLE_TESTS OFF CACHE INTERNAL "")
+        FetchContent_MakeAvailable(zlib-ng)
+
+        if(TARGET ZLIB::ZLIB)
+            MATIO_CREATE_ZLIB("ZLIB::ZLIB")
+        elseif(TARGET zlib)
+            MATIO_CREATE_ZLIB(zlib)
+        else()
+            message(FATAL_ERROR "Failed to build zlib-ng in compat mode")
+        endif()
+    endif()
+endif()
+
+if(MATIO_WITH_ZLIB AND NOT MATIO_USE_ZLIB_NG)
     if(MATIO_USE_CONAN AND NOT MATIO_WITH_HDF5)
         conan_cmake_run(REQUIRES "zlib/[>=1.2.3]" BASIC_SETUP CMAKE_TARGETS OPTIONS BUILD missing)
     endif()
@@ -115,8 +161,8 @@ if(MATIO_WITH_ZLIB)
             MATIO_CREATE_ZLIB(ZLIB::ZLIB)
         endif()
     endif()
+endif()
 
-    if(ZLIB_FOUND)
-        set(HAVE_ZLIB 1)
-    endif()
+if(MATIO_WITH_ZLIB AND ZLIB_FOUND)
+    set(HAVE_ZLIB 1)
 endif()

--- a/cmake/thirdParties.cmake
+++ b/cmake/thirdParties.cmake
@@ -99,37 +99,58 @@ if(MATIO_USE_ZLIB_NG AND MATIO_WITH_ZLIB)
     # which uses standard zlib types (z_streamp, inflate, etc.)
     find_package(zlib-ng QUIET CONFIG)
     if(zlib-ng_FOUND)
-        if(TARGET ZLIB::ZLIB)
-            MATIO_CREATE_ZLIB("ZLIB::ZLIB")
-        elseif(TARGET ZLIB::zlibstatic)
-            MATIO_CREATE_ZLIB("ZLIB::zlibstatic")
-        elseif(TARGET zlib-ng::zlib AND TARGET zlib)
-            # zlib-ng with ZLIB_ALIASES and ZLIB_COMPAT
-            MATIO_CREATE_ZLIB(zlib)
-        elseif(TARGET zlib-ng::zlibstatic AND TARGET zlibstatic)
-            MATIO_CREATE_ZLIB(zlibstatic)
+        if(NOT MATIO_SHARED)
+            # Static build: prefer static zlib-ng libraries
+            if(TARGET ZLIB::zlibstatic)
+                MATIO_CREATE_ZLIB("ZLIB::zlibstatic")
+            elseif(TARGET zlib-ng::zlibstatic AND TARGET zlibstatic)
+                MATIO_CREATE_ZLIB(zlibstatic)
+            elseif(TARGET ZLIB::ZLIB)
+                MATIO_CREATE_ZLIB("ZLIB::ZLIB")
+            elseif(TARGET zlib-ng::zlib AND TARGET zlib)
+                MATIO_CREATE_ZLIB(zlib)
+            else()
+                message(FATAL_ERROR
+                    "zlib-ng found but not built with zlib compatibility. "
+                    "Set MATIO_USE_ZLIB_NG=OFF or rebuild zlib-ng with -DZLIB_COMPAT=ON."
+                )
+            endif()
         else()
-            message(FATAL_ERROR
-                "zlib-ng found but not built with zlib compatibility. "
-                "Set MATIO_USE_ZLIB_NG=OFF or rebuild zlib-ng with -DZLIB_COMPAT=ON."
-            )
+            # Shared build: prefer shared zlib-ng libraries
+            if(TARGET ZLIB::ZLIB)
+                MATIO_CREATE_ZLIB("ZLIB::ZLIB")
+            elseif(TARGET zlib-ng::zlib AND TARGET zlib)
+                MATIO_CREATE_ZLIB(zlib)
+            elseif(TARGET ZLIB::zlibstatic)
+                MATIO_CREATE_ZLIB("ZLIB::zlibstatic")
+            elseif(TARGET zlib-ng::zlibstatic AND TARGET zlibstatic)
+                MATIO_CREATE_ZLIB(zlibstatic)
+            else()
+                message(FATAL_ERROR
+                    "zlib-ng found but not built with zlib compatibility. "
+                    "Set MATIO_USE_ZLIB_NG=OFF or rebuild zlib-ng with -DZLIB_COMPAT=ON."
+                )
+            endif()
         endif()
     else()
         # Fallback: fetch and build zlib-ng from source (always in compat mode)
         message(STATUS "zlib-ng not found on system, fetching from GitHub")
         FetchContent_Declare(zlib-ng
             GIT_REPOSITORY https://github.com/zlib-ng/zlib-ng
-            GIT_TAG        12731092979c6d07f42da27da673a9f6c7b13586
+            GIT_TAG        2.3.3
             GIT_SHALLOW    TRUE
+            EXCLUDE_FROM_ALL
         )
-        set(ZLIB_COMPAT ON CACHE BOOL "Build zlib-ng with zlib compatibility" FORCE)
-        set(ZLIB_ENABLE_TESTS OFF CACHE INTERNAL "")
+        set(ZLIB_COMPAT ON)
+        set(BUILD_TESTING OFF)
         FetchContent_MakeAvailable(zlib-ng)
 
-        if(TARGET ZLIB::ZLIB)
-            MATIO_CREATE_ZLIB("ZLIB::ZLIB")
-        elseif(TARGET zlib)
-            MATIO_CREATE_ZLIB(zlib)
+        if(NOT MATIO_SHARED AND TARGET zlib-ng-static)
+            MATIO_CREATE_ZLIB(zlib-ng-static)
+            install(TARGETS zlib-ng-static)
+        elseif(MATIO_SHARED AND TARGET zlib-ng)
+            MATIO_CREATE_ZLIB(zlib-ng)
+            install(TARGETS zlib-ng)
         else()
             message(FATAL_ERROR "Failed to build zlib-ng in compat mode")
         endif()

--- a/documentation/build.texi
+++ b/documentation/build.texi
@@ -102,6 +102,13 @@ HDF5 library (see section 2.1.2 for information about HDF5).
 @item MATIO_WITH_ZLIB:BOOL=ON
 This option enables CMake to check for availability of the
 zlib library (see section 2.1.1 for information about zlib).
+@item MATIO_USE_ZLIB_NG:BOOL=OFF
+This option enables zlib-ng as an alternative zlib implementation
+(see section 2.1.1 for information about zlib). When enabled, CMake
+searches for zlib-ng via its own CMake config file before falling
+back to regular zlib. zlib-ng can be built with or without zlib
+compatibility; in either case matio will adapt automatically.
+Set @code{ZLIBNG_ROOT} to a directory containing a zlib-ng installation.
 @item MATIO_MATLAB:BOOL=OFF
 This option enables MATLAB verification of written MAT files in the testsuite.
 MATLAB can be available either locally or on a remote host via SSH.


### PR DESCRIPTION
@MaartenBent Kindly asking for review, espcially the FetchContent fallback which is currently not found for other dependencies. Thank you.