### PR TITLE
bound sparse ir/jc/data reads to allocation in Mat_VarRead73

### DIFF
--- a/src/mat73.c
+++ b/src/mat73.c
@@ -3203,6 +3203,13 @@ Mat_VarRead73(mat_t *mat, matvar_t *matvar)
                     size_t nbytes = 0;
                     sparse_data->nir = (mat_uint32_t)dims[0];
                     free(dims);
+                    if ( rank != 1 || (hsize_t)sparse_data->nir != nelems ) {
+                        H5Dclose(sparse_dset_id);
+                        H5Gclose(dset_id);
+                        free(sparse_data);
+                        err = MATIO_E_FILE_FORMAT_VIOLATION;
+                        goto done;
+                    }
                     err = Mul(&nbytes, sparse_data->nir, sizeof(mat_uint32_t));
                     if ( err ) {
                         H5Dclose(sparse_dset_id);
@@ -3253,6 +3260,15 @@ Mat_VarRead73(mat_t *mat, matvar_t *matvar)
                     size_t nbytes = 0;
                     sparse_data->njc = (mat_uint32_t)dims[0];
                     free(dims);
+                    if ( rank != 1 || (hsize_t)sparse_data->njc != nelems ) {
+                        H5Dclose(sparse_dset_id);
+                        H5Gclose(dset_id);
+                        if ( sparse_data->ir != NULL )
+                            free(sparse_data->ir);
+                        free(sparse_data);
+                        err = MATIO_E_FILE_FORMAT_VIOLATION;
+                        goto done;
+                    }
                     err = Mul(&nbytes, sparse_data->njc, sizeof(mat_uint32_t));
                     if ( err ) {
                         H5Dclose(sparse_dset_id);
@@ -3310,6 +3326,17 @@ Mat_VarRead73(mat_t *mat, matvar_t *matvar)
                     sparse_data->nzmax = (mat_uint32_t)dims[0];
                     sparse_data->ndata = (mat_uint32_t)dims[0];
                     free(dims);
+                    if ( rank != 1 || (hsize_t)sparse_data->nzmax != nelems ) {
+                        H5Dclose(sparse_dset_id);
+                        H5Gclose(dset_id);
+                        if ( sparse_data->jc != NULL )
+                            free(sparse_data->jc);
+                        if ( sparse_data->ir != NULL )
+                            free(sparse_data->ir);
+                        free(sparse_data);
+                        err = MATIO_E_FILE_FORMAT_VIOLATION;
+                        goto done;
+                    }
                     err = Mul(&ndata_bytes, sparse_data->nzmax, Mat_SizeOf(matvar->data_type));
                     if ( err ) {
                         H5Dclose(sparse_dset_id);


### PR DESCRIPTION
Repro: open a v7.3 file whose sparse `ir`, `jc`, or `data` subdataset is stored with rank > 1, so its element count exceeds `dims[0]`.
Cause: the `MAT_C_SPARSE` path in `Mat_VarRead73` sizes each buffer from `dims[0]` but `H5Dread` fills the whole dataset (product of all dims), overflowing the heap allocation.
Fix: require each subdataset to be a 1-D vector whose length matches the allocation before reading it.

Confirmed with ASAN: a 2-D `ir` turns an 8-byte allocation into a 24-byte write before the patch, and is rejected cleanly after, with the sparse round-trip tests still passing.