### PR TITLE
bound GetDataSlab whole-array memcpy to a full column selection

### DIFF
--- a/src/mat5.c
+++ b/src/mat5.c
@@ -4779,8 +4779,8 @@ GetDataSlab(void *data_in, void *data_out, enum matio_classes class_type,
             err = MATIO_E_BAD_ARGUMENT;
         else if ( (size_t)stride[1] * (edge[1] - 1) + start[1] + 1 > dims[1] )
             err = MATIO_E_BAD_ARGUMENT;
-        else if ( (stride[0] == 1 && (size_t)edge[0] == dims[0]) && (stride[1] == 1) &&
-                  (same_type == 1) )
+        else if ( (stride[0] == 1 && (size_t)edge[0] == dims[0]) &&
+                  (stride[1] == 1 && (size_t)edge[1] == dims[1]) && (same_type == 1) )
             memcpy(data_out, data_in, nbytes);
         else {
             int i, j;


### PR DESCRIPTION
Repro: read a partial column range (edge[1] < dims[1]) from a compressed 2-D numeric struct field or cell element with Mat_VarReadData.
Cause: the rank-2 fast path in GetDataSlab copies the whole variable (matvar->nbytes) but only guards edge[0] == dims[0], so a caller buffer sized to the selection (edge[0]*edge[1]) is overrun when fewer columns are requested.
Fix: take the whole-buffer memcpy only when the second dimension is fully selected too; otherwise fall through to the element-wise slab copy.

ASAN on the pre-read (in-memory) path shows a write of the full dims[0]*dims[1] element count into the edge-sized output at mat5.c:4784 via Mat_VarReadData5 -> GetDataSlab; with the guard the requested columns read back correctly and the run stays clean.