### PR TITLE
Validate read range up front in Mat_VarReadDataLinear5

### DIFF
--- a/src/mat5.c
+++ b/src/mat5.c
@@ -5304,6 +5304,15 @@ Mat_VarReadDataLinear5(mat_t *mat, matvar_t *matvar, void *data, int start, int 
 
     if ( mat->version == MAT_FT_MAT4 )
         return -1;
+
+    err = Mat_MulDims(matvar, &nelems);
+    if ( err ) {
+        Mat_Critical("Integer multiplication overflow");
+        return err;
+    }
+    if ( (size_t)stride * (edge - 1) + start + 1 > nelems )
+        return MATIO_E_BAD_ARGUMENT;
+
     (void)fseeko((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
     if ( matvar->compression == MAT_COMPRESSION_NONE ) {
         err = Read(tag, 4, 2, (FILE *)mat->fp, NULL);
@@ -5377,20 +5386,7 @@ Mat_VarReadDataLinear5(mat_t *mat, matvar_t *matvar, void *data, int start, int 
     if ( real_bytes % 8 )
         real_bytes += (8 - (real_bytes % 8));
 
-    err = Mat_MulDims(matvar, &nelems);
-    if ( err ) {
-        Mat_Critical("Integer multiplication overflow");
-#if HAVE_ZLIB
-        if ( z_copy ) {
-            inflateEnd(&z);
-        }
-#endif
-        return err;
-    }
-
-    if ( (size_t)stride * (edge - 1) + start + 1 > nelems ) {
-        err = MATIO_E_BAD_ARGUMENT;
-    } else if ( matvar->compression == MAT_COMPRESSION_NONE ) {
+    if ( matvar->compression == MAT_COMPRESSION_NONE ) {
         if ( matvar->isComplex ) {
             mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
 


### PR DESCRIPTION
Repro: open a compressed file whose struct field or cell element is small enough to be pre-read into internal->data, then call Mat_VarReadDataLinear with start/edge past the element count.
Cause: Mat_VarReadDataLinear5 range-checks stride/edge/start only after it dispatches the already-read fast path, so GetDataLinear copies past the pre-read buffer.
Fix: hoist the check ahead of the fast path, the way Mat_VarReadDataLinear4 already does.
