### PR TITLE
validate edge product in Mat_VarGetCells and Mat_VarGetStructs

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -19,6 +19,7 @@
 #endif
 #include "safe-math.h"
 #include <assert.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -519,6 +520,36 @@ Add(size_t *res, size_t a, size_t b)
         return MATIO_E_INDEX_TOO_BIG;
     }
 
+    return MATIO_E_NO_ERROR;
+}
+
+/** @brief Checks the product of the edge dimensions for overflow
+ *
+ * Validates that each edge is non-negative and that the product of the edge
+ * dimensions does not overflow and stays within @c INT_MAX, so that the result
+ * can be used as an @c int element count.
+ * @param rank Number of dimensions
+ * @param edge Number of elements to read per dimension
+ * @retval 0 on success
+ */
+int
+CheckEdgeOverflow(int rank, const int *edge, size_t extra)
+{
+    int i, err;
+    size_t nElements = 1;
+    for ( i = 0; i < rank; i++ ) {
+        if ( edge[i] < 0 ) {
+            return MATIO_E_BAD_ARGUMENT;
+        }
+        err = Mul(&nElements, nElements, (size_t)edge[i]);
+        if ( err || nElements > (size_t)INT_MAX ) {
+            return MATIO_E_INDEX_TOO_BIG;
+        }
+    }
+    err = Mul(&nElements, nElements, extra);
+    if ( err || nElements > (size_t)INT_MAX ) {
+        return MATIO_E_INDEX_TOO_BIG;
+    }
     return MATIO_E_NO_ERROR;
 }
 

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -5859,7 +5859,7 @@ ReadOpaqueInfo5(mat_t *mat, matvar_t *matvar, const mat_uint32_t *name_tag)
     char *type_name = NULL;
     char *class_name = NULL;
 
-    /* Array name — use pre-read tag */
+    /* Array name - use pre-read tag */
     err = ReadTaggedString(mat, &matvar->name, name_tag);
     if ( err )
         return err;

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -608,7 +608,7 @@ Mat_H5ReadVarInfo(matvar_t *matvar, hid_t dset_id)
 #if defined(MCOS) && MCOS
             if ( H5Iget_type(dset_id) == H5I_DATASET && 0 != strcmp(class_str, "logical") &&
                  0 != strcmp(class_str, "unknown") ) {
-                /* Likely an MCOS object — store class name and mark as opaque */
+                /* Likely an MCOS object - store class name and mark as opaque */
                 matvar->class_type = MAT_C_OPAQUE;
                 matvar->internal->class_name = strdup(class_str);
                 matvar->internal->type_name = strdup("MCOS");
@@ -622,7 +622,7 @@ Mat_H5ReadVarInfo(matvar_t *matvar, hid_t dset_id)
                 matvar->data_type = MAT_T_UINT8;
             } else if ( H5Iget_type(dset_id) == H5I_GROUP && 0 != strcmp(class_str, "logical") &&
                         0 != strcmp(class_str, "unknown") ) {
-                /* Group with unknown class (e.g. enum instance) — treat as struct */
+                /* Group with unknown class (e.g. enum instance) - treat as struct */
                 matvar->class_type = MAT_C_STRUCT;
             }
 #endif

--- a/src/matio_private.h
+++ b/src/matio_private.h
@@ -276,6 +276,7 @@ EXTERN int Mat_MulDims(const matvar_t *matvar, size_t *nelems);
 EXTERN int Read(void *buf, size_t size, size_t count, FILE *fp, size_t *bytesread);
 EXTERN int IsEndOfFile(FILE *fp, mat_off_t *fpos);
 EXTERN int CheckSeekFile(FILE *fp, mat_off_t offset);
+EXTERN int CheckEdgeOverflow(int rank, const int *edge, size_t extra);
 
 /* io.c */
 #if defined(_WIN32)

--- a/src/matvar_cell.c
+++ b/src/matvar_cell.c
@@ -7,6 +7,7 @@
  */
 
 #include "matio_private.h"
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -81,6 +82,17 @@ Mat_VarGetCells(const matvar_t *matvar, const int *start, const int *stride, con
         return NULL;
     } else if ( matvar->rank > 9 ) {
         return NULL;
+    }
+
+    {
+        int k;
+        size_t nelems = 1;
+        for ( k = 0; k < matvar->rank; k++ ) {
+            if ( edge[k] < 0 || Mul(&nelems, nelems, (size_t)edge[k]) ||
+                 nelems > (size_t)INT_MAX ) {
+                return NULL;
+            }
+        }
     }
 
     ndata = matvar->nbytes / sizeof(matvar_t *);

--- a/src/matvar_cell.c
+++ b/src/matvar_cell.c
@@ -7,7 +7,6 @@
  */
 
 #include "matio_private.h"
-#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -84,15 +83,8 @@ Mat_VarGetCells(const matvar_t *matvar, const int *start, const int *stride, con
         return NULL;
     }
 
-    {
-        int k;
-        size_t nelems = 1;
-        for ( k = 0; k < matvar->rank; k++ ) {
-            if ( edge[k] < 0 || Mul(&nelems, nelems, (size_t)edge[k]) ||
-                 nelems > (size_t)INT_MAX ) {
-                return NULL;
-            }
-        }
+    if ( CheckEdgeOverflow(matvar->rank, edge, 1) ) {
+        return NULL;
     }
 
     ndata = matvar->nbytes / sizeof(matvar_t *);

--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -402,17 +402,8 @@ Mat_VarGetStructs(const matvar_t *matvar, const int *start, const int *stride, c
         return NULL;
     }
 
-    {
-        int k;
-        size_t nelems = 1;
-        for ( k = 0; k < matvar->rank; k++ ) {
-            if ( edge[k] < 0 || Mul(&nelems, nelems, (size_t)edge[k]) ) {
-                return NULL;
-            }
-        }
-        if ( Mul(&nelems, nelems, matvar->internal->num_fields) || nelems > (size_t)INT_MAX ) {
-            return NULL;
-        }
+    if ( CheckEdgeOverflow(matvar->rank, edge, matvar->internal->num_fields) ) {
+        return NULL;
     }
 
     struct_slab = Mat_VarDuplicate(matvar, 0);

--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -7,6 +7,7 @@
  */
 
 #include "matio_private.h"
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #if defined(_MSC_VER) || defined(__MINGW32__)
@@ -399,6 +400,19 @@ Mat_VarGetStructs(const matvar_t *matvar, const int *start, const int *stride, c
     }
     if ( matvar->data == NULL ) {
         return NULL;
+    }
+
+    {
+        int k;
+        size_t nelems = 1;
+        for ( k = 0; k < matvar->rank; k++ ) {
+            if ( edge[k] < 0 || Mul(&nelems, nelems, (size_t)edge[k]) ) {
+                return NULL;
+            }
+        }
+        if ( Mul(&nelems, nelems, matvar->internal->num_fields) || nelems > (size_t)INT_MAX ) {
+            return NULL;
+        }
     }
 
     struct_slab = Mat_VarDuplicate(matvar, 0);

--- a/src/mcos.c
+++ b/src/mcos.c
@@ -1043,7 +1043,7 @@ ParseSubsystem5(mat_t *mat)
             trailing_shared_cells = 1;
         }
 
-        /* Cell 2 (index 1): Empty/reserved — skip */
+        /* Cell 2 (index 1): Empty/reserved - skip */
 
         /* Cells 3.. contain property content cells. FileWrapper__ v4 adds
          * three trailing shared cells: unknown, class alias metadata, defaults.
@@ -1242,7 +1242,7 @@ ParseSubsystem73(mat_t *mat)
             trailing_shared_cells = 1;
         }
 
-        /* Cell 1: Empty/reserved — skip */
+        /* Cell 1: Empty/reserved - skip */
 
         /* Cells 2..N: property content */
         if ( ncells > 2 + trailing_shared_cells )
@@ -1329,7 +1329,7 @@ ResolveMCOS(mcos_subsystem_t *ss, matvar_t *matvar)
 
     num_objs = matvar->internal->num_objects;
     if ( num_objs == 0 || matvar->internal->object_ids == NULL ) {
-        /* No object IDs — leave as opaque */
+        /* No object IDs - leave as opaque */
         return MATIO_E_NO_ERROR;
     }
 
@@ -1389,7 +1389,7 @@ ResolveMCOS(mcos_subsystem_t *ss, matvar_t *matvar)
     nfields = all_fieldnames_count;
     if ( nfields == 0 ) {
         free(all_fieldnames);
-        /* Object with no properties — set it up as an empty struct-like object */
+        /* Object with no properties - set it up as an empty struct-like object */
         matvar->class_type = MAT_C_OBJECT;
         matvar->data_type = MAT_T_STRUCT;
         matvar->data_size = sizeof(matvar_t *);

--- a/src/read_data.c
+++ b/src/read_data.c
@@ -532,23 +532,6 @@ ReadCharData(mat_t *mat, void *_data, enum matio_types data_type, size_t len)
     } while ( 0 )
 
 static int
-CheckEdgeOverflow(int rank, const int *edge)
-{
-    int i, err;
-    size_t nElements = 1;
-    for ( i = 0; i < rank; i++ ) {
-        if ( edge[i] < 0 ) {
-            return 1;
-        }
-        err = Mul(&nElements, nElements, (size_t)edge[i]);
-        if ( err || nElements > (size_t)INT_MAX ) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
-static int
 CheckSlabOverflow(int rank, const size_t *dims, const int *start, const int *stride)
 {
     int i, j;
@@ -615,7 +598,7 @@ ReadDataSlabN(mat_t *mat, void *data, enum matio_classes class_type, enum matio_
         return MATIO_E_BAD_ARGUMENT;
     }
 
-    if ( CheckEdgeOverflow(rank, edge) ) {
+    if ( CheckEdgeOverflow(rank, edge, 1) ) {
         return MATIO_E_BAD_ARGUMENT;
     }
 
@@ -813,7 +796,7 @@ ReadCompressedDataSlabN(mat_t *mat, z_streamp z, void *data, enum matio_classes 
         return -1;
     }
 
-    if ( CheckEdgeOverflow(rank, edge) ) {
+    if ( CheckEdgeOverflow(rank, edge, 1) ) {
         return -1;
     }
 
@@ -1073,7 +1056,7 @@ ReadDataSlab2(mat_t *mat, void *data, enum matio_classes class_type, enum matio_
         return MATIO_E_BAD_ARGUMENT;
     }
 
-    if ( CheckEdgeOverflow(2, edge) ) {
+    if ( CheckEdgeOverflow(2, edge, 1) ) {
         return MATIO_E_BAD_ARGUMENT;
     }
 
@@ -1328,7 +1311,7 @@ ReadCompressedDataSlab2(mat_t *mat, z_streamp z, void *data, enum matio_classes 
         return 0;
     }
 
-    if ( CheckEdgeOverflow(2, edge) ) {
+    if ( CheckEdgeOverflow(2, edge, 1) ) {
         return -1;
     }
 


### PR DESCRIPTION
Repro: Mat_VarGetCells on a rank-2 cell array with edge={3, 1431655766}.
Cause: N, the product of edge[], is accumulated in a signed int with no overflow guard. 3*1431655766 wraps to 2, so the pointer array is malloc'd for two cells while the copy loop still writes cells[0..2], one past the allocation (ASan heap-buffer-overflow in matvar_cell.c). Mat_VarGetStructs sizes its field array from the same unchecked product.
Fix: reject a negative edge or a product past INT_MAX before the allocation in both, matching CheckEdgeOverflow in the fixed-rank slab readers. Valid selections are unchanged.
