### PR TITLE
Avoid out-of-bounds dims read for a scalar HDF5 dataspace

### DIFF
--- a/src/mat73.c
+++ b/src/mat73.c
@@ -707,6 +707,21 @@ Mat_H5ReadDims(hid_t dset_id, hsize_t *nelems, int *rank)
         H5Sclose(space_id);
         return NULL;
     }
+    if ( 0 == *rank ) {
+        /* Scalar (rank-0) dataspace. A malloc(0) here hands the callers that
+         * read dims[0] (empty-array and sparse ir/jc/data readers) a
+         * zero-length buffer, so they read out of bounds. Return one zeroed
+         * element instead; rank stays 0 so callers that special-case a scalar
+         * still do, and those reading dims[0] see a defined value. */
+        perm_dims = (size_t *)calloc(1, sizeof(*perm_dims));
+        H5Sclose(space_id);
+        if ( NULL != perm_dims ) {
+            *nelems = 1;
+        } else {
+            Mat_Critical("Error allocating memory for matvar->dims");
+        }
+        return perm_dims;
+    }
     perm_dims = (size_t *)malloc(*rank * sizeof(*perm_dims));
     if ( NULL != perm_dims ) {
         int err = 0;


### PR DESCRIPTION
Repro: open a v7.3 file with a numeric dataset stored as a scalar (rank-0) HDF5 dataspace and marked MATLAB_empty, or a sparse variable whose ir/jc/data subdataset is stored the same way.
Cause: Mat_H5ReadDims sizes its result with malloc(*rank * sizeof(size_t)), so a scalar dataspace gives malloc(0); Mat_H5ReadDatasetInfo's empty branch and the sparse ir/jc/data readers in Mat_VarRead73 then read dims[0] off that zero-length buffer (ASan heap-buffer-overflow read at mat73.c:920 and :3204).
Fix: return one zeroed element for a scalar dataspace so dims[0] stays in bounds. rank stays 0, so the struct-field reader that already special-cases a scalar is unchanged and the malformed empty/sparse datasets are rejected downstream.
