### PR TITLE
Enable support for structure w/o MATLAB_fields attribute in HDF5 MAT-file

### DIFF
--- a/src/mat73.c
+++ b/src/mat73.c
@@ -1218,7 +1218,8 @@ Mat_H5ReadGroupInfo(mat_t *mat, matvar_t *matvar, hid_t dset_id)
             /* First iteration to retrieve number of relevant links */
             herr = H5Literate(dset_id, H5_INDEX_NAME, H5_ITER_NATIVE, NULL,
                               Mat_H5ReadGroupInfoIterate, (void *)&group_data);
-            if ( herr > 0 && group_data.nfields > 0 ) {
+            /* H5Literate returns 0 on full success; >0 only if callback short-circuits */
+            if ( herr >= 0 && group_data.nfields > 0 ) {
                 matvar->internal->fieldnames = (char **)calloc(
                     (size_t)(group_data.nfields), sizeof(*matvar->internal->fieldnames));
                 group_data.nfields = 0;
@@ -1484,7 +1485,8 @@ Mat_H5ReadGroupInfoIterate(hid_t dset_id, const char *name, const H5L_info_t *in
             break;
     }
 
-    return 1;
+    /* Return 0 so H5Literate continues over all structure fields */
+    return 0;
 }
 
 static int

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -111,6 +111,7 @@ TEST_DATAFILES = $(datasets_dir)/large_struct_compressed_le.mat \
                  $(datasets_dir)/test_type_systems_v73.mat \
                  $(datasets_dir)/test_user_defined_v7.mat \
                  $(datasets_dir)/test_user_defined_v73.mat \
+                 $(datasets_dir)/issue321_v73_nofields.mat \
                  $(matlab_dir)/test_write_1d_logical.m \
                  $(matlab_dir)/test_write_2d_logical.m \
                  $(matlab_dir)/test_write_1d_numeric.m \
@@ -145,6 +146,7 @@ TEST_DATAFILES = $(datasets_dir)/large_struct_compressed_le.mat \
                  $(results_dir)/dir_le.out \
                  $(results_dir)/dir-5_be.out \
                  $(results_dir)/dir-73_be.out \
+                 $(results_dir)/dump-issue321.out \
                  $(results_dir)/dump-large_struct_compressed.out \
                  $(results_dir)/dump-large_struct_compressed_32.out \
                  $(results_dir)/dump-mat_copy-4.out \
@@ -222,6 +224,7 @@ TEST_DATAFILES = $(datasets_dir)/large_struct_compressed_le.mat \
                  $(results_dir)/dump-var89-4.out \
                  $(results_dir)/getstructfield-large_struct_compressed.out \
                  $(results_dir)/ind2sub.out \
+                 $(results_dir)/read-issue321.out \
                  $(results_dir)/read-packed_field_name.out \
                  $(results_dir)/read-nullpad_class_name.out \
                  $(results_dir)/readslab-var1.out \

--- a/test/results/dump-issue321.out
+++ b/test/results/dump-issue321.out
@@ -1,0 +1,7 @@
+      Name: s
+      Rank: 2
+Class Type: Structure
+Fields[2] {
+1 2 3 4 
+2 3 4 5 
+}

--- a/test/results/read-issue321.out
+++ b/test/results/read-issue321.out
@@ -1,0 +1,23 @@
+      Name: s
+      Rank: 2
+Dimensions: 1 x 1
+Class Type: Structure
+ Data Type: Structure
+Fields[2] {
+      Name: a
+      Rank: 2
+Dimensions: 1 x 4
+Class Type: Double Precision Array
+ Data Type: IEEE 754 double-precision
+{
+1 2 3 4 
+}
+      Name: b
+      Rank: 2
+Dimensions: 1 x 4
+Class Type: Double Precision Array
+ Data Type: IEEE 754 double-precision
+{
+2 3 4 5 
+}
+}

--- a/test/tests/mat73_uncompressed_read_le.at
+++ b/test/tests/mat73_uncompressed_read_le.at
@@ -469,3 +469,12 @@ AT_SKIP_IF([test $MAT73 -ne 1])
 AT_CHECK([cp $srcdir/results/read-nullpad_class_name.out expout
          $builddir/../tools/matdump -d $srcdir/datasets/struct_nullpad_class_name_hdf_le.mat],[0],[expout],[])
 AT_CLEANUP
+
+AT_SETUP([Read struct without MATLAB_fields attribute])
+AT_KEYWORDS([structure])
+AT_SKIP_IF([test $MAT73 -ne 1])
+AT_CHECK([cp $srcdir/results/read-issue321.out expout
+         $builddir/test_mat readvar $srcdir/datasets/issue321_v73_nofields.mat s],[0],[expout],[])
+AT_CHECK([cp $srcdir/results/dump-issue321.out expout
+         $builddir/../tools/matdump -d $srcdir/datasets/issue321_v73_nofields.mat s],[0],[expout],[])
+AT_CLEANUP


### PR DESCRIPTION
```matlab
s.a = [1, 2, 3,4]; s.b=[2,3,4,5];
save('s.mat', 's');
```
```c
mat_t* matfp = Mat_Open(filename, MAT_ACC_RDONLY);
matvar_t* matvar = Mat_VarReadNext(matfp);
unsigned fields_num = Mat_VarGetNumberOfFields(matvar); // fields_num == 1
```

- mat73: s.a = [1, 2, 3,4]; s.b=[2,3,4,5]; save('s.mat', 's'); only read s.a;
- mat5: no bug
- fix bug by Cursor-AI
- Update H5Literate return value handling in Mat_H5ReadGroupInfo and Mat_H5ReadGroupInfoIterate functions