### PR TITLE
bound MCOS pointer-array walks to the allocated size

### DIFF
--- a/src/mcos.c
+++ b/src/mcos.c
@@ -1018,6 +1018,11 @@ ParseSubsystem5(mat_t *mat)
                 goto cleanup_ss;
         }
 
+        /* ncells is derived from the cell dimensions; make sure the pointer
+         * array actually holds that many entries before indexing it. */
+        if ( ncells == 0 || ncells > mcos_var->nbytes / sizeof(matvar_t *) )
+            goto cleanup_ss;
+
         /* Cell 1 (index 0): Linking metadata as uint8 array */
         cell1 = cells[0];
         if ( cell1 == NULL || cell1->data == NULL )
@@ -1605,6 +1610,7 @@ ResolveNestedMCOS(mcos_subsystem_t *ss, matvar_t *matvar, int depth)
     if ( matvar->class_type == MAT_C_CELL && matvar->data != NULL ) {
         matvar_t **cells = (matvar_t **)matvar->data;
         size_t ncells = 1;
+        size_t ndata = matvar->nbytes / sizeof(matvar_t *);
         size_t i;
 
         {
@@ -1612,6 +1618,12 @@ ResolveNestedMCOS(mcos_subsystem_t *ss, matvar_t *matvar, int depth)
             if ( err )
                 return err;
         }
+
+        /* The dimensions come from the subsystem metadata and can disagree
+         * with the number of pointers actually stored in matvar->data. Walk
+         * only what was allocated. */
+        if ( ncells > ndata )
+            ncells = ndata;
 
         for ( i = 0; i < ncells; i++ ) {
             if ( cells[i] == NULL )
@@ -1627,6 +1639,7 @@ ResolveNestedMCOS(mcos_subsystem_t *ss, matvar_t *matvar, int depth)
         size_t nfields = matvar->internal->num_fields;
         size_t nelems = 1;
         size_t total = 0;
+        size_t ndata = matvar->nbytes / sizeof(matvar_t *);
         size_t i;
         matvar_t **fields = (matvar_t **)matvar->data;
 
@@ -1638,6 +1651,9 @@ ResolveNestedMCOS(mcos_subsystem_t *ss, matvar_t *matvar, int depth)
 
         if ( Mul(&total, nfields, nelems) )
             return MATIO_E_INDEX_TOO_BIG;
+
+        if ( total > ndata )
+            total = ndata;
 
         for ( i = 0; i < total; i++ ) {
             if ( fields[i] == NULL )


### PR DESCRIPTION
Repro: read a v5 file whose MCOS subsystem encodes a cell/object whose dimensions imply more elements than the stored `matvar_t *` array holds (`test_mat readvar` or `matdump -d` on such a file).

Cause: `ResolveNestedMCOS` derives the child count from the product of `matvar->dims` (times `num_fields` for the struct/object branch) and walks `cells[i]`/`fields[i]` over it, but the dimensions come from subsystem metadata and are not tied to what was actually allocated in `matvar->data`. When they disagree the loop reads past the pointer array and dereferences the out-of-bounds pointer (ASan heap-buffer-overflow READ at mcos.c:1603 and :1624). `ParseSubsystem5` has the same trust issue on the top-level FileWrapper__ array: it dereferences `cells[0]` right after `Mat_MulDims`, ahead of the `ncells >= 3/5` checks, so a zero- or short-length cell array is indexed out of bounds. The v7.3 path `ParseSubsystem73` already validates the cell count before indexing.

Fix: clamp both walks in `ResolveNestedMCOS` to `nbytes / sizeof(matvar_t *)`, and reject a FileWrapper cell array whose element count exceeds its allocation before using it. For well-formed files the dimensions and the allocation agree, so nothing is clamped and output is unchanged (verified against the committed MCOS dump results).