### PR TITLE
bound rank in GetDataSlab rank-N slab copy

### DIFF
--- a/src/mat5.c
+++ b/src/mat5.c
@@ -4845,6 +4845,8 @@ GetDataSlab(void *data_in, void *data_out, enum matio_classes class_type,
                     break;
             }
         }
+    } else if ( rank > 10 ) {
+        err = MATIO_E_BAD_ARGUMENT;
     } else {
         int i, j, N, I = 0;
         int inc[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
Repro: read a compressed variable whose cell element or struct field is declared rank 11-13, then call Mat_VarReadData on that element.
Cause: for a pre-read compressed member Mat_VarReadData5 dispatches to GetDataSlab, whose rank!=2 path writes inc/cnt/dimp[i] into fixed size-10 stack arrays without bounding rank; the file-based sibling ReadDataSlabN rejects rank>10 up front, GetDataSlab never did.
Fix: reject rank>10 in GetDataSlab before the slab walk, matching ReadDataSlabN.