### PR TITLE
Fix off-by-one field index check in Mat_VarGetStructFieldByIndex

### DIFF
--- a/src/matvar_struct.c
+++ b/src/matvar_struct.c
@@ -248,10 +248,10 @@ Mat_VarGetStructFieldByIndex(const matvar_t *matvar, size_t field_index, size_t 
 
     nfields = matvar->internal->num_fields;
 
-    if ( nelems > 0 && index >= nelems ) {
+    if ( index >= nelems ) {
         Mat_Critical("Mat_VarGetStructField: structure index out of bounds");
     } else if ( nfields > 0 ) {
-        if ( field_index > nfields ) {
+        if ( field_index >= nfields ) {
             Mat_Critical("Mat_VarGetStructField: field index out of bounds");
         } else {
             field = *((matvar_t **)matvar->data + index * nfields + field_index);


### PR DESCRIPTION
Mat_VarGetStructFieldByIndex range-checks field_index with `>` rather than `>=`, so a field index equal to the field count passes and the function reads one matvar_t* past the end of the nelems*nfields pointer array, then hands that out-of-bounds word back to the caller as a field. The structure index is unbounded too whenever Mat_MulDims reports zero elements, since the `nelems > 0 &&` short circuit drops that check entirely for a rank 0 struct. Reading the `structure` variable out of share/test_file_v6.mat and asking for field index 3 of element 5 is enough to trip ASan at matvar_struct.c:257 (READ of size 8, 0 bytes after the 144-byte block from AllocateStructFields); both comparisons now match what Mat_VarSetStructFieldByIndex already does.