### PR TITLE
saturate float-to-integer conversion in the typed data readers

### DIFF
--- a/src/read_data.c
+++ b/src/read_data.c
@@ -23,7 +23,25 @@
 #include <math.h>
 #include <time.h>
 
-#define READ_DATA_NOSWAP(T)                                           \
+/* Conversion of a value read from the file into the destination type T.
+ * Casting an out-of-range (or NaN/Inf) floating value to an integer type is
+ * undefined behavior (C11 6.3.1.4), which a crafted file can reach whenever a
+ * floating source type is read into an integer destination (e.g. v4 sparse
+ * row/column indices are stored as double and read into mat_uint32_t). Integer
+ * sources keep the existing modular cast; floating sources saturate to the
+ * destination range and map NaN to 0, leaving every in-range value unchanged. */
+#define MAT_TYPE_IS_SIGNED(T) (((T) - 1) < ((T)0))
+#define MAT_TYPE_MAX(T) \
+    (MAT_TYPE_IS_SIGNED(T) ? (T)((((T)1 << (sizeof(T) * CHAR_BIT - 2)) - 1) * 2 + 1) : (T) ~(T)0)
+#define MAT_TYPE_MIN(T) (MAT_TYPE_IS_SIGNED(T) ? (T)(-MAT_TYPE_MAX(T) - 1) : (T)0)
+#define MAT_CAST_PLAIN(T, x) ((T)(x))
+#define MAT_CAST_SAT(T, x)                                      \
+    ((x) != (x)                               ? (T)0            \
+     : (double)(x) <= (double)MAT_TYPE_MIN(T) ? MAT_TYPE_MIN(T) \
+     : (double)(x) >= (double)MAT_TYPE_MAX(T) ? MAT_TYPE_MAX(T) \
+                                              : (T)(x))
+
+#define READ_DATA_NOSWAP(T, CVT)                                      \
     do {                                                              \
         const size_t block_size = READ_BLOCK_SIZE / data_size;        \
         err = MATIO_E_NO_ERROR;                                       \
@@ -31,7 +49,7 @@
             readCount = fread(v, data_size, len, (FILE *)mat->fp);    \
             if ( readCount == len ) {                                 \
                 for ( i = 0; i < len; i++ ) {                         \
-                    data[i] = (T)v[i];                                \
+                    data[i] = CVT(T, v[i]);                           \
                 }                                                     \
             } else {                                                  \
                 err = MATIO_E_GENERIC_READ_ERROR;                     \
@@ -45,7 +63,7 @@
                 readCount += j;                                       \
                 if ( j == block_size ) {                              \
                     for ( j = 0; j < block_size; j++ ) {              \
-                        data[i + j] = (T)v[j];                        \
+                        data[i + j] = CVT(T, v[j]);                   \
                     }                                                 \
                 } else {                                              \
                     err = MATIO_E_GENERIC_READ_ERROR;                 \
@@ -60,7 +78,7 @@
                 readCount += j;                                       \
                 if ( j == len - i ) {                                 \
                     for ( j = 0; j < len - i; j++ ) {                 \
-                        data[i + j] = (T)v[j];                        \
+                        data[i + j] = CVT(T, v[j]);                   \
                     }                                                 \
                 } else {                                              \
                     err = MATIO_E_GENERIC_READ_ERROR;                 \
@@ -70,7 +88,7 @@
         }                                                             \
     } while ( 0 )
 
-#define READ_DATA(T, SwapFunc)                                            \
+#define READ_DATA(T, SwapFunc, CVT)                                       \
     do {                                                                  \
         if ( mat->byteswap ) {                                            \
             const size_t block_size = READ_BLOCK_SIZE / data_size;        \
@@ -79,7 +97,8 @@
                 readCount = fread(v, data_size, len, (FILE *)mat->fp);    \
                 if ( readCount == len ) {                                 \
                     for ( i = 0; i < len; i++ ) {                         \
-                        data[i] = (T)SwapFunc(&v[i]);                     \
+                        (void)SwapFunc(&v[i]);                            \
+                        data[i] = CVT(T, v[i]);                           \
                     }                                                     \
                 } else {                                                  \
                     err = MATIO_E_GENERIC_READ_ERROR;                     \
@@ -93,7 +112,8 @@
                     readCount += j;                                       \
                     if ( j == block_size ) {                              \
                         for ( j = 0; j < block_size; j++ ) {              \
-                            data[i + j] = (T)SwapFunc(&v[j]);             \
+                            (void)SwapFunc(&v[j]);                        \
+                            data[i + j] = CVT(T, v[j]);                   \
                         }                                                 \
                     } else {                                              \
                         err = MATIO_E_GENERIC_READ_ERROR;                 \
@@ -108,7 +128,8 @@
                     readCount += j;                                       \
                     if ( j == len - i ) {                                 \
                         for ( j = 0; j < len - i; j++ ) {                 \
-                            data[i + j] = (T)SwapFunc(&v[j]);             \
+                            (void)SwapFunc(&v[j]);                        \
+                            data[i + j] = CVT(T, v[j]);                   \
                         }                                                 \
                     } else {                                              \
                         err = MATIO_E_GENERIC_READ_ERROR;                 \
@@ -117,7 +138,7 @@
                 }                                                         \
             }                                                             \
         } else {                                                          \
-            READ_DATA_NOSWAP(T);                                          \
+            READ_DATA_NOSWAP(T, CVT);                                     \
             if ( err ) {                                                  \
                 break;                                                    \
             }                                                             \
@@ -125,7 +146,7 @@
     } while ( 0 )
 
 #if HAVE_ZLIB
-#define READ_COMPRESSED_DATA_NOSWAP(T)                                                \
+#define READ_COMPRESSED_DATA_NOSWAP(T, CVT)                                           \
     do {                                                                              \
         const size_t block_size = READ_BLOCK_SIZE / data_size;                        \
         if ( len <= block_size ) {                                                    \
@@ -134,7 +155,7 @@
                 break;                                                                \
             }                                                                         \
             for ( i = 0; i < len; i++ ) {                                             \
-                data[i] = (T)v[i];                                                    \
+                data[i] = CVT(T, v[i]);                                               \
             }                                                                         \
         } else {                                                                      \
             mat_uint32_t j;                                                           \
@@ -145,7 +166,7 @@
                     break;                                                            \
                 }                                                                     \
                 for ( j = 0; j < block_size; j++ ) {                                  \
-                    data[i + j] = (T)v[j];                                            \
+                    data[i + j] = CVT(T, v[j]);                                       \
                 }                                                                     \
             }                                                                         \
             if ( err ) {                                                              \
@@ -157,12 +178,12 @@
                 break;                                                                \
             }                                                                         \
             for ( j = 0; j < len; j++ ) {                                             \
-                data[i + j] = (T)v[j];                                                \
+                data[i + j] = CVT(T, v[j]);                                           \
             }                                                                         \
         }                                                                             \
     } while ( 0 )
 
-#define READ_COMPRESSED_DATA(T, SwapFunc)                                                 \
+#define READ_COMPRESSED_DATA(T, SwapFunc, CVT)                                            \
     do {                                                                                  \
         if ( mat->byteswap ) {                                                            \
             const size_t block_size = READ_BLOCK_SIZE / data_size;                        \
@@ -172,7 +193,8 @@
                     break;                                                                \
                 }                                                                         \
                 for ( i = 0; i < len; i++ ) {                                             \
-                    data[i] = (T)SwapFunc(&v[i]);                                         \
+                    (void)SwapFunc(&v[i]);                                                \
+                    data[i] = CVT(T, v[i]);                                               \
                 }                                                                         \
             } else {                                                                      \
                 mat_uint32_t j;                                                           \
@@ -183,7 +205,8 @@
                         break;                                                            \
                     }                                                                     \
                     for ( j = 0; j < block_size; j++ ) {                                  \
-                        data[i + j] = (T)SwapFunc(&v[j]);                                 \
+                        (void)SwapFunc(&v[j]);                                            \
+                        data[i + j] = CVT(T, v[j]);                                       \
                     }                                                                     \
                 }                                                                         \
                 if ( err ) {                                                              \
@@ -195,11 +218,12 @@
                     break;                                                                \
                 }                                                                         \
                 for ( j = 0; j < len; j++ ) {                                             \
-                    data[i + j] = (T)SwapFunc(&v[j]);                                     \
+                    (void)SwapFunc(&v[j]);                                                \
+                    data[i + j] = CVT(T, v[j]);                                           \
                 }                                                                         \
             }                                                                             \
         } else {                                                                          \
-            READ_COMPRESSED_DATA_NOSWAP(T);                                               \
+            READ_COMPRESSED_DATA_NOSWAP(T, CVT);                                          \
             if ( err ) {                                                                  \
                 break;                                                                    \
             }                                                                             \
@@ -407,7 +431,7 @@ ReadCharData(mat_t *mat, void *_data, enum matio_types data_type, size_t len)
             size_t i, readCount;
             mat_uint16_t *data = (mat_uint16_t *)_data;
             mat_uint16_t v[READ_BLOCK_SIZE / sizeof(mat_uint16_t)];
-            READ_DATA(mat_uint16_t, Mat_uint16Swap);
+            READ_DATA(mat_uint16_t, Mat_uint16Swap, MAT_CAST_PLAIN);
             break;
         }
         default:

--- a/src/read_data_impl.h
+++ b/src/read_data_impl.h
@@ -6,6 +6,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+/* Conversion applied when a floating source (double/single) is read into this
+ * destination type. A floating destination stays a plain cast; an integer
+ * destination saturates so the out-of-range float-to-integer conversion is not
+ * undefined behavior. */
+#if READ_TYPE_TYPE == READ_TYPE_DOUBLE || READ_TYPE_TYPE == READ_TYPE_SINGLE
+#define READ_FLOAT_CVT MAT_CAST_PLAIN
+#else
+#define READ_FLOAT_CVT MAT_CAST_SAT
+#endif
+
 #define READ_TYPE_DOUBLE_DATA CAT(READ_TYPED_FUNC1, Double)
 #define READ_TYPE_SINGLE_DATA CAT(READ_TYPED_FUNC1, Single)
 #define READ_TYPE_INT32_DATA CAT(READ_TYPED_FUNC1, Int32)
@@ -42,7 +52,7 @@ READ_TYPE_DOUBLE_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(double);
     double v[READ_BLOCK_SIZE / sizeof(double)];
-    READ_DATA(READ_TYPE, Mat_doubleSwap);
+    READ_DATA(READ_TYPE, Mat_doubleSwap, READ_FLOAT_CVT);
 #endif
     return err;
 }
@@ -68,7 +78,7 @@ READ_TYPE_SINGLE_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(float);
     float v[READ_BLOCK_SIZE / sizeof(float)];
-    READ_DATA(READ_TYPE, Mat_floatSwap);
+    READ_DATA(READ_TYPE, Mat_floatSwap, READ_FLOAT_CVT);
 #endif
     return err;
 }
@@ -94,7 +104,7 @@ READ_TYPE_INT32_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(mat_int32_t);
     mat_int32_t v[READ_BLOCK_SIZE / sizeof(mat_int32_t)];
-    READ_DATA(READ_TYPE, Mat_int32Swap);
+    READ_DATA(READ_TYPE, Mat_int32Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -120,7 +130,7 @@ READ_TYPE_UINT32_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(mat_uint32_t);
     mat_uint32_t v[READ_BLOCK_SIZE / sizeof(mat_uint32_t)];
-    READ_DATA(READ_TYPE, Mat_uint32Swap);
+    READ_DATA(READ_TYPE, Mat_uint32Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -146,7 +156,7 @@ READ_TYPE_INT16_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(mat_int16_t);
     mat_int16_t v[READ_BLOCK_SIZE / sizeof(mat_int16_t)];
-    READ_DATA(READ_TYPE, Mat_int16Swap);
+    READ_DATA(READ_TYPE, Mat_int16Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -172,7 +182,7 @@ READ_TYPE_UINT16_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(mat_uint16_t);
     mat_uint16_t v[READ_BLOCK_SIZE / sizeof(mat_uint16_t)];
-    READ_DATA(READ_TYPE, Mat_uint16Swap);
+    READ_DATA(READ_TYPE, Mat_uint16Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -192,7 +202,7 @@ READ_TYPE_INT8_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(mat_int8_t);
     mat_int8_t v[READ_BLOCK_SIZE / sizeof(mat_int8_t)];
-    READ_DATA_NOSWAP(READ_TYPE);
+    READ_DATA_NOSWAP(READ_TYPE, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -212,7 +222,7 @@ READ_TYPE_UINT8_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(mat_uint8_t);
     mat_uint8_t v[READ_BLOCK_SIZE / sizeof(mat_uint8_t)];
-    READ_DATA_NOSWAP(READ_TYPE);
+    READ_DATA_NOSWAP(READ_TYPE, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -239,7 +249,7 @@ READ_TYPE_INT64_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(mat_int64_t);
     mat_int64_t v[READ_BLOCK_SIZE / sizeof(mat_int64_t)];
-    READ_DATA(READ_TYPE, Mat_int64Swap);
+    READ_DATA(READ_TYPE, Mat_int64Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -267,7 +277,7 @@ READ_TYPE_UINT64_DATA(mat_t *mat, READ_TYPE *data, size_t len)
     size_t i;
     const size_t data_size = sizeof(mat_uint64_t);
     mat_uint64_t v[READ_BLOCK_SIZE / sizeof(mat_uint64_t)];
-    READ_DATA(READ_TYPE, Mat_uint64Swap);
+    READ_DATA(READ_TYPE, Mat_uint64Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -373,7 +383,7 @@ READ_TYPE_DOUBLE_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len
     mat_uint32_t i;
     const size_t data_size = sizeof(double);
     double v[READ_BLOCK_SIZE / sizeof(double)];
-    READ_COMPRESSED_DATA(READ_TYPE, Mat_doubleSwap);
+    READ_COMPRESSED_DATA(READ_TYPE, Mat_doubleSwap, READ_FLOAT_CVT);
 #endif
     return err;
 }
@@ -397,7 +407,7 @@ READ_TYPE_SINGLE_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len
     mat_uint32_t i;
     const size_t data_size = sizeof(float);
     float v[READ_BLOCK_SIZE / sizeof(float)];
-    READ_COMPRESSED_DATA(READ_TYPE, Mat_floatSwap);
+    READ_COMPRESSED_DATA(READ_TYPE, Mat_floatSwap, READ_FLOAT_CVT);
 #endif
     return err;
 }
@@ -422,7 +432,7 @@ READ_TYPE_INT64_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len)
     mat_uint32_t i;
     const size_t data_size = sizeof(mat_int64_t);
     mat_int64_t v[READ_BLOCK_SIZE / sizeof(mat_int64_t)];
-    READ_COMPRESSED_DATA(READ_TYPE, Mat_int64Swap);
+    READ_COMPRESSED_DATA(READ_TYPE, Mat_int64Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -448,7 +458,7 @@ READ_TYPE_UINT64_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len
     mat_uint32_t i;
     const size_t data_size = sizeof(mat_uint64_t);
     mat_uint64_t v[READ_BLOCK_SIZE / sizeof(mat_uint64_t)];
-    READ_COMPRESSED_DATA(READ_TYPE, Mat_uint64Swap);
+    READ_COMPRESSED_DATA(READ_TYPE, Mat_uint64Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -473,7 +483,7 @@ READ_TYPE_INT32_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len)
     mat_uint32_t i;
     const size_t data_size = sizeof(mat_int32_t);
     mat_int32_t v[READ_BLOCK_SIZE / sizeof(mat_int32_t)];
-    READ_COMPRESSED_DATA(READ_TYPE, Mat_int32Swap);
+    READ_COMPRESSED_DATA(READ_TYPE, Mat_int32Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -497,7 +507,7 @@ READ_TYPE_UINT32_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len
     mat_uint32_t i;
     const size_t data_size = sizeof(mat_uint32_t);
     mat_uint32_t v[READ_BLOCK_SIZE / sizeof(mat_uint32_t)];
-    READ_COMPRESSED_DATA(READ_TYPE, Mat_uint32Swap);
+    READ_COMPRESSED_DATA(READ_TYPE, Mat_uint32Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -521,7 +531,7 @@ READ_TYPE_INT16_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len)
     mat_uint32_t i;
     const size_t data_size = sizeof(mat_int16_t);
     mat_int16_t v[READ_BLOCK_SIZE / sizeof(mat_int16_t)];
-    READ_COMPRESSED_DATA(READ_TYPE, Mat_int16Swap);
+    READ_COMPRESSED_DATA(READ_TYPE, Mat_int16Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -545,7 +555,7 @@ READ_TYPE_UINT16_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len
     mat_uint32_t i;
     const size_t data_size = sizeof(mat_uint16_t);
     mat_uint16_t v[READ_BLOCK_SIZE / sizeof(mat_uint16_t)];
-    READ_COMPRESSED_DATA(READ_TYPE, Mat_uint16Swap);
+    READ_COMPRESSED_DATA(READ_TYPE, Mat_uint16Swap, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -560,7 +570,7 @@ READ_TYPE_INT8_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len)
     mat_uint32_t i;
     const size_t data_size = sizeof(mat_int8_t);
     mat_int8_t v[READ_BLOCK_SIZE / sizeof(mat_int8_t)];
-    READ_COMPRESSED_DATA_NOSWAP(READ_TYPE);
+    READ_COMPRESSED_DATA_NOSWAP(READ_TYPE, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -575,7 +585,7 @@ READ_TYPE_UINT8_DATA(mat_t *mat, z_streamp z, READ_TYPE *data, mat_uint32_t len)
     mat_uint32_t i;
     const size_t data_size = sizeof(mat_uint8_t);
     mat_uint8_t v[READ_BLOCK_SIZE / sizeof(mat_uint8_t)];
-    READ_COMPRESSED_DATA_NOSWAP(READ_TYPE);
+    READ_COMPRESSED_DATA_NOSWAP(READ_TYPE, MAT_CAST_PLAIN);
 #endif
     return err;
 }
@@ -646,3 +656,5 @@ READ_TYPED_FUNC2(mat_t *mat, z_streamp z, READ_TYPE *data, enum matio_types data
 #endif /* HAVE_MAT_UINT64_T */
 
 #endif
+
+#undef READ_FLOAT_CVT


### PR DESCRIPTION
Repro: read any v4 sparse matrix whose row/column index (stored as double) falls outside uint32 range; ReadUInt32Data casts it straight into mat_uint32_t.
Cause: the typed readers in read_data_impl.h convert a double/single element to an integer destination with a plain (T)v[i] cast, which is undefined for an out-of-range or NaN value (C11 6.3.1.4). Reachable from Mat_VarRead4/Mat_VarRead5 for any floating-stored, integer-typed array.
Fix: saturate a floating source to the destination range (NaN maps to 0) before the narrowing cast, in the uncompressed and compressed readers alike; integer sources keep the existing modular cast, so every in-range value stays byte-identical (full ctest suite still passes).

Fixes #241