### PR TITLE
reject non-finite dimensions in v4 sparse reader

### DIFF
--- a/src/mat4.c
+++ b/src/mat4.c
@@ -397,7 +397,7 @@ Mat_VarRead4(mat_t *mat, matvar_t *matvar)
                     }
                 }
                 err = ReadDoubleData(mat, &tmp, data_type, 1);
-                if ( err || tmp > UINT_MAX - 1 || tmp < 0 ) {
+                if ( err || !(tmp >= 0 && tmp <= UINT_MAX - 1) ) {
                     free(sparse->ir);
                     free(matvar->data);
                     matvar->data = NULL;
@@ -416,7 +416,7 @@ Mat_VarRead4(mat_t *mat, matvar_t *matvar)
                 }
                 (void)fseeko((FILE *)mat->fp, sparse->nir * Mat_SizeOf(data_type), SEEK_CUR);
                 err = ReadDoubleData(mat, &tmp, data_type, 1);
-                if ( err || tmp > UINT_MAX - 1 || tmp < 0 ) {
+                if ( err || !(tmp >= 0 && tmp <= UINT_MAX - 1) ) {
                     free(sparse->ir);
                     free(matvar->data);
                     matvar->data = NULL;


### PR DESCRIPTION
Repro: a v4 sparse array whose stored type is double and whose row or column dimension element is a NaN, read through Mat_VarReadNext/Mat_VarReadDataAll.
Cause: the guard `tmp > UINT_MAX - 1 || tmp < 0` in the MAT_C_SPARSE branch of Mat_VarRead4 lets NaN pass, since every ordered comparison against NaN is false, so `(size_t)tmp` then converts a NaN, which is undefined behavior (C11 6.3.1.4). UBSan flags it at mat4.c:407 for the row dimension and mat4.c:426 for the column.
Fix: require a finite in-range value at both casts. Positive and negative infinity were already rejected by the old range test; this closes the remaining NaN gap without changing behavior for valid dimensions.