### PR TITLE
avoid signed shift overflow decoding subsystem offset in ParseSubsystem5

### DIFF
--- a/src/mcos.c
+++ b/src/mcos.c
@@ -843,7 +843,7 @@ ParseSubsystem5(mat_t *mat)
             Mat_uint32Swap(&lo);
             Mat_uint32Swap(&hi);
         }
-        subsys_pos = (mat_off_t)lo | ((mat_off_t)hi << 32);
+        subsys_pos = (mat_off_t)((mat_uint64_t)lo | ((mat_uint64_t)hi << 32));
     }
 
     if ( subsys_pos <= 0 )


### PR DESCRIPTION
Repro: read a v5/v7 file carrying an MCOS object whose header subsystem offset has the top bit of the high dword set (e.g. 0x80000000d3); reading it reaches Mat_MCOS_Read5 -> GetSubsystem5 -> ParseSubsystem5.
Cause: the 8-byte offset is rebuilt from two uint32 halves as (mat_off_t)hi << 32, and mat_off_t is signed 64-bit, so a hi with its top bit set shifts a positive value past INT64_MAX. UBSan: "left shift of 2147483648 by 32 places cannot be represented in type 'long'" at mcos.c:846. The out-of-range offset is only rejected afterwards (subsys_pos <= 0 / fseeko), so the UB runs before any check.
Fix: assemble the value in mat_uint64_t before narrowing to mat_off_t, matching how the header writer in mat.c already splits and reassembles it.