### PR TITLE
size utf-16 conversion buffer by byte count in char writer

### DIFF
--- a/src/mat73.c
+++ b/src/mat73.c
@@ -2126,7 +2126,12 @@ Mat_VarWriteChar73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims)
         if ( !err && matvar->data_type == MAT_T_UTF8 ) {
             /* Convert to UTF-16 */
             h5type = H5T_NATIVE_UINT16;
-            u16 = (mat_uint16_t *)calloc(nelems, sizeof(mat_uint16_t));
+            /* The loop below emits one code unit per decoded UTF-8 code point
+             * and walks matvar->nbytes input bytes, so the number of writes is
+             * bounded by nbytes, which can exceed nelems when the variable was
+             * read from a file whose declared dimensions undercount its bytes.
+             */
+            u16 = (mat_uint16_t *)calloc(matvar->nbytes, sizeof(mat_uint16_t));
             if ( u16 != NULL ) {
                 const mat_uint8_t *data = (const mat_uint8_t *)matvar->data;
                 size_t i, j = 0;


### PR DESCRIPTION
Repro: read a v5 MAT_C_CHAR array stored as UTF-8 whose declared dimensions undercount its byte payload, then write it to a v7.3 file.
Cause: Mat_VarWriteChar73 sizes the UTF-16 scratch buffer from the dimension product (nelems), but the conversion loop walks matvar->nbytes input bytes and emits one code unit per code point. Mat_VarRead5 only enforces nelems <= nbytes for char, so a crafted file can leave nbytes above nelems and the loop writes past the buffer.
Fix: size the buffer from matvar->nbytes, which bounds the number of code units the loop can emit and still covers the nelems elements handed to H5Dwrite.

ASan on the round trip, before: heap-buffer-overflow WRITE of size 2 in Mat_VarWriteChar73 (calloc'd nelems, 2-byte region); after: clean, valid files unchanged.