### PR TITLE
Size opaque metadata buffer by checked element count in Mat_VarRead73

### DIFF
--- a/src/mat73.c
+++ b/src/mat73.c
@@ -3569,9 +3569,14 @@ Mat_VarRead73(mat_t *mat, matvar_t *matvar)
                         H5Sclose(space_id);
                     }
                     if ( nelems > 0 ) {
-                        /* Read the raw data as uint32 values */
-                        mat_uint32_t *meta =
-                            (mat_uint32_t *)malloc((size_t)nelems * sizeof(mat_uint32_t));
+                        /* Size the buffer with a checked multiply so it matches
+                         * the element count passed to H5Screate_simple below. */
+                        size_t meta_size = 0;
+                        mat_uint32_t *meta = NULL;
+                        if ( (hsize_t)(size_t)nelems == nelems &&
+                             0 == Mul(&meta_size, (size_t)nelems, sizeof(mat_uint32_t)) ) {
+                            meta = (mat_uint32_t *)malloc(meta_size);
+                        }
                         if ( meta != NULL ) {
                             hid_t mem_space_id = H5Screate_simple(1, &nelems, NULL);
                             herr_t herr = H5Dread(opaque_id, H5T_NATIVE_UINT32, mem_space_id,

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -3574,7 +3574,7 @@ Mat_VarRead73(mat_t *mat, matvar_t *matvar)
                         size_t meta_size = 0;
                         mat_uint32_t *meta = NULL;
                         if ( (hsize_t)(size_t)nelems == nelems &&
-                             0 == Mul(&meta_size, (size_t)nelems, sizeof(mat_uint32_t)) ) {
+                             MATIO_E_NO_ERROR == Mul(&meta_size, (size_t)nelems, sizeof(mat_uint32_t)) ) {
                             meta = (mat_uint32_t *)malloc(meta_size);
                         }
                         if ( meta != NULL ) {

--- a/src/mat73.c
+++ b/src/mat73.c
@@ -3574,7 +3574,8 @@ Mat_VarRead73(mat_t *mat, matvar_t *matvar)
                         size_t meta_size = 0;
                         mat_uint32_t *meta = NULL;
                         if ( (hsize_t)(size_t)nelems == nelems &&
-                             MATIO_E_NO_ERROR == Mul(&meta_size, (size_t)nelems, sizeof(mat_uint32_t)) ) {
+                             MATIO_E_NO_ERROR ==
+                                 Mul(&meta_size, (size_t)nelems, sizeof(mat_uint32_t)) ) {
                             meta = (mat_uint32_t *)malloc(meta_size);
                         }
                         if ( meta != NULL ) {


### PR DESCRIPTION
Repro: read a v7.3 file with an unknown-class integer dataset (classified MAT_C_OPAQUE) whose dataspace element count is near the integer limits.
Cause: the opaque branch sizes the uint32 metadata buffer with a raw `(size_t)nelems * sizeof(mat_uint32_t)`, but H5Dread fills `nelems` elements from the H5S_ALL selection, so the byte multiply wraps (and `nelems` truncates on a 32-bit size_t) and H5Dread writes past the allocation.
Fix: size the buffer with the overflow-checked `Mul` used by the other readers and skip the read when the count would overflow or truncate, keeping the allocation in step with the `H5Screate_simple` element count.