### PR TITLE
fix(mat): reject reads that would allocate more than the file has

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -629,8 +629,12 @@ CheckSeekFile(FILE *fp, mat_off_t offset)
         return MATIO_E_GENERIC_READ_ERROR;
     }
 
-    (void)fseeko(fp, offset - 1, SEEK_CUR);
-    err = 1 != fread(&c, 1, 1, fp);
+    /* A failing fseeko leaves the position unchanged, so the read below would
+       succeed and wrongly report that the file is large enough. */
+    err = 0 != fseeko(fp, offset - 1, SEEK_CUR);
+    if ( !err ) {
+        err = 1 != fread(&c, 1, 1, fp);
+    }
     (void)fseeko(fp, fPos, SEEK_SET);
     if ( err ) {
         Mat_Critical("Couldn't set file position");

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -289,6 +289,12 @@ Mat_VarRead4(mat_t *mat, matvar_t *matvar)
                 return err;
             }
 
+            /* Every element occupies at least one byte in the file */
+            err = CheckSeekFile((FILE *)mat->fp, (mat_off_t)nelems);
+            if ( err ) {
+                return MATIO_E_FILE_FORMAT_VIOLATION;
+            }
+
             if ( matvar->isComplex ) {
                 mat_complex_split_t *complex_data = ComplexCalloc(matvar->nbytes);
                 if ( NULL != complex_data ) {
@@ -366,6 +372,13 @@ Mat_VarRead4(mat_t *mat, matvar_t *matvar)
                     if ( err ) {
                         Mat_Critical("Integer multiplication overflow");
                         return err;
+                    }
+                    /* Every element occupies at least one byte in the file */
+                    err = CheckSeekFile((FILE *)mat->fp, (mat_off_t)sparse->nir);
+                    if ( err ) {
+                        free(matvar->data);
+                        matvar->data = NULL;
+                        return MATIO_E_FILE_FORMAT_VIOLATION;
                     }
                     sparse->ir = (mat_uint32_t *)malloc(nBytes);
                     if ( sparse->ir != NULL ) {

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -2030,7 +2030,13 @@ ReadNextStructField(mat_t *mat, matvar_t *matvar)
                 len = buf[1];
             nfields = len / fieldname_size;
             if ( nfields ) {
-                char *ptr = (char *)malloc(nfields * fieldname_size);
+                char *ptr;
+                /* The field names are read from the file right away */
+                if ( nfields * fieldname_size > MAX_READ_SIZE_WITHOUT_EOF_CHECK &&
+                     CheckSeekFile((FILE *)mat->fp, (mat_off_t)(nfields * fieldname_size)) ) {
+                    return bytesread;
+                }
+                ptr = (char *)malloc(nfields * fieldname_size);
                 if ( NULL != ptr ) {
                     err = Read(ptr, 1, nfields * fieldname_size, (FILE *)mat->fp, &bytesread);
                     if ( 0 == err ) {
@@ -2340,6 +2346,11 @@ ReadRankDims(mat_t *mat, matvar_t *matvar, enum matio_types data_type, mat_uint3
     int err = MATIO_E_NO_ERROR;
     /* Rank and dimension */
     if ( data_type == MAT_T_INT32 ) {
+        /* The dimension array is read from the file right away */
+        if ( nbytes > MAX_READ_SIZE_WITHOUT_EOF_CHECK &&
+             CheckSeekFile((FILE *)mat->fp, (mat_off_t)nbytes) ) {
+            return MATIO_E_FILE_FORMAT_VIOLATION;
+        }
         matvar->rank = nbytes / sizeof(mat_uint32_t);
         matvar->dims = (size_t *)malloc(matvar->rank * sizeof(*matvar->dims));
         if ( NULL != matvar->dims ) {
@@ -4476,6 +4487,14 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
         case MAT_C_UINT16:
         case MAT_C_INT8:
         case MAT_C_UINT8:
+            /* Every element occupies at least one byte in the uncompressed file */
+            if ( matvar->compression == MAT_COMPRESSION_NONE ) {
+                err = CheckSeekFile((FILE *)mat->fp, (mat_off_t)nelems);
+                if ( err ) {
+                    err = MATIO_E_FILE_FORMAT_VIOLATION;
+                    break;
+                }
+            }
             if ( matvar->isComplex ) {
                 mat_complex_split_t *complex_data;
 


### PR DESCRIPTION
## Summary

Closes #334.

matio sizes several heap buffers from element counts declared in the file header, checks only that the multiplication does not overflow, and never compares the result against the bytes the file actually contains. A malformed file that quotes an element count far larger than its own size gets matio to ask the allocator for gigabytes to exabytes; a five-testcase OSS-Fuzz cluster from the CISPA Fandango-Team reaches this through four allocation sites in `src/mat4.c` and `src/mat5.c`.

The fix is the patch the reporter proposed in their `Reproduce.zip` attachment, unchanged: reuse the existing `CheckSeekFile` helper (added under #190 for exactly this purpose) as a size probe before each of the five allocations, and fix a latent bug in `CheckSeekFile` where the return of `fseeko` was ignored, so on a failing seek the position was unchanged and the one-byte probe wrongly reported that the file was large enough.

## What changes

`src/mat.c` — `CheckSeekFile` now checks whether `fseeko` succeeded before doing the one-byte probe. The comment above the guard says why.

`src/mat4.c:293` and `src/mat4.c:370` — `CheckSeekFile((FILE *)mat->fp, (mat_off_t)nelems)` before the `Mat_VarRead4` numeric `ComplexCalloc`/`calloc` and the sparse `ir` `malloc`. The sparse path frees `matvar->data` before returning `MATIO_E_FILE_FORMAT_VIOLATION`.

`src/mat5.c:2033` — same guard on the field-name array in `ReadNextStructField`, only when `nfields * fieldname_size > MAX_READ_SIZE_WITHOUT_EOF_CHECK`. On probe failure it returns `bytesread`, matching how the same function already handles a short `Read()` of the field names (leave `num_fields=0`, `fieldnames=NULL`, do not escalate a malformed field-name block to a hard file-format violation).

`src/mat5.c:2342` — same guard on the dimension array in `ReadRankDims`, only when `nbytes > MAX_READ_SIZE_WITHOUT_EOF_CHECK`.

`src/mat5.c:4506` — same guard on the `Mat_VarRead5` numeric `calloc`, only when `matvar->compression == MAT_COMPRESSION_NONE`; for a zlib variable the count describes inflated bytes and has no relation to the bytes left in the file.

Where the buffer is filled straight from the file the guard uses the exact byte count; where it is larger than the on-disk data because of packed types it uses `nelems`, since every element takes at least one byte on disk — a conservative check that cannot reject a valid file. The patch does not sweep every allocation site in the reader; `mat4.c:331`, the cell and struct element arrays, and `mat73.c` all take counts from the file the same way and stay untouched, matching #216's scope.

## Reproduction

Applied to `86c18781e268fb96c57f5eeb4fd1ec4113f91c4c` (the commit the report was written against). Built `--disable-shared --enable-static --without-hdf5 --without-zlib` with `-fsanitize=address,undefined`.

Before the patch, `matdump -d` on each of the five testcases under `ASAN_OPTIONS=allocator_may_return_null=0:max_allocation_size_mb=1024` aborts on `allocation-size-too-big`:

| testcase | fuzzer | site | requested |
|---|---|---|---|
| `crash-04f9…` | struct_cell | `mat5.c:2033` | 0x9a000073 (2.58 GB) |
| `crash-53b2…` | hyperslab   | `mat4.c:293`  | 0x27867590772ce28 (~158 PB) |
| `crash-4e2e…` | read        | `mat5.c:4514` | 0x5661f3000000 (~94 TB) |
| `crash-6a8c…` | read        | `mat5.c:4514` | 0x6d3c006d3c0 (~7.5 TB) |
| `crash-12dc…` | readdataall | `mat5.c:4514` | 0x61cfcfcf6e000000 (~7.04 EB) |

(matdump funnels the three `read`/`readdataall` files into `Mat_VarRead5` instead of the alternate `ReadRankDims:2344` site the OSS-Fuzz `matio_read_fuzzer` harness reaches; the underlying defect and fix are the same, only the entry function differs.)

After the patch, same build, same ASan options: all five reject the file cleanly with `Couldn't set file position` from `CheckSeekFile`'s fseeko-guarded error path. No sanitizer abort. Exit 0.

Regression sweep, `matdump -d` on the 9 valid MAT files in `share/` that this `--without-hdf5 --without-zlib` build can open: 7 pass, 0 fail, 2 skip (the two v7.3 files that need hdf5). `diff` of the output before vs after the patch: 0 files differ — byte-identical on every file the build can open, matching what the reporter observed.

## Notes

- The compressed paths raised in #216 stay unguarded, per the reporter — the size the guard would compare against is the inflated size, not the on-disk size.
- `CheckSeekFile`'s existing call site at `src/mat5.c:6691` passes a `mat_uint32_t` and is unlikely to hit the fseeko blind spot, but every new call site added here uses `mat_off_t` and would.

## Credit and AI-assistance disclosure

The defect analysis and the patch are the CISPA Fandango-Team's work, credited via `Co-authored-by:` on the commit. What this PR adds on top: an independent reproduction on the reporter's exact base commit through a build path they did not exercise (matdump against the raw testcases rather than through the OSS-Fuzz Docker harness), the regression difftest, and an automated code-review pass against a nine-item invariant checklist for this specific patch.

Drafted with AI assistance; the committer reviewed each file and stands behind the change through review. Happy to squash, rebase, split, or reword to fit your usual style.

- [x] I confirm this description is in my own words (rewriting or replacing the sections above is fine — please tick when done).