### PR TITLE
avoid divide-by-zero cast in Mat_CalcSubscripts for zero dims

### DIFF
--- a/src/mat.c
+++ b/src/mat.c
@@ -2284,8 +2284,12 @@ Mat_CalcSubscripts(int rank, const int *dims, int index)
         int k = 1;
         for ( j = i; j--; )
             k *= dims[j];
-        subs[i] = (int)floor(l / (double)k);
-        l -= subs[i] * k;
+        if ( k != 0 ) {
+            subs[i] = (int)floor(l / (double)k);
+            l -= subs[i] * k;
+        } else {
+            subs[i] = 0;
+        }
         subs[i]++;
     }
 
@@ -2328,8 +2332,12 @@ Mat_CalcSubscripts2(int rank, const size_t *dims, size_t index)
         size_t k = 1;
         for ( j = i; j--; )
             k *= dims[j];
-        subs[i] = (size_t)floor(l / (double)k);
-        l -= (double)(subs[i] * k);
+        if ( k != 0 ) {
+            subs[i] = (size_t)floor(l / (double)k);
+            l -= (double)(subs[i] * k);
+        } else {
+            subs[i] = 0;
+        }
         subs[i]++;
     }
 


### PR DESCRIPTION
Repro: call Mat_CalcSubscripts (or Mat_CalcSubscripts2) on a variable that has a zero-size dimension, e.g. dims {0,3} read from a MAT file. UBSan reports "inf is outside the range of representable values of type 'int'" at mat.c:2287 (and the size_t twin at mat.c:2331); index 0 gives nan instead of inf, and subs[i]++ then overflows.
Cause: both helpers reconstruct per-dimension subscripts by dividing the running index by k, the product of the lower dimensions, as a double and casting the quotient back to int/size_t. k is never checked for zero, so a zero dimension makes the divisor 0, the double division yields inf/nan, and casting a non-finite double to an integer type is undefined behavior (C11 6.3.1.4). These are exported helpers, so the dims come from whatever variable a caller read, including empty arrays.
Fix: skip the division when k is 0 and leave that subscript at 0. For any array with nonzero dimensions k stays positive and the result is unchanged; the full ctest suite (8713 cases) passes.
